### PR TITLE
fix: don't run changeset status command on version packages branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: yarn build:all
       - name: Changeset
         run: yarn changeset status --since origin/main
-        if: ${{ github.ref_name != 'main' }}
+        if: ${{ (github.ref_name != 'main') && (github.ref_name != 'changeset-release/main') }}


### PR DESCRIPTION
This disables the `yarn changeset status` check for the `changset-release/main` branch.