### PR TITLE
fix: use correct github context param for changeset check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: yarn build:all
       - name: Changeset
         run: yarn changeset status --since origin/main
-        if: ${{ (github.ref_name != 'main') && (github.ref_name != 'changeset-release/main') }}
+        if: ${{ github.ref_name != 'main' && github.head_ref != 'changeset-release/main' }}


### PR DESCRIPTION
ref_name was in the format of XX/merge.
head_ref is the name of the branch the PR is from.