### PR TITLE
chore: rename test coverage github workflow

### DIFF
--- a/.github/workflows/testCoverage.yml
+++ b/.github/workflows/testCoverage.yml
@@ -8,7 +8,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  build:
+  coverage:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This resolves a conflict in the required PR status checks.