### PR TITLE
fix: add pluginId to plugins

### DIFF
--- a/.changeset/lazy-rice-check.md
+++ b/.changeset/lazy-rice-check.md
@@ -1,0 +1,6 @@
+---
+'@globallogicuki/backstage-plugin-terraform-backend': patch
+'@globallogicuki/backstage-plugin-terraform': patch
+---
+
+fix: add pluginId to each plugin

--- a/plugins/terraform-backend/package.json
+++ b/plugins/terraform-backend/package.json
@@ -19,7 +19,11 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin"
+    "role": "backend-plugin",
+    "pluginId": "terraform-backend",
+    "pluginPackages": [
+      "@globallogicuki/backstage-plugin-terraform-backend"
+    ]
   },
   "scripts": {
     "start": "backstage-cli package start",

--- a/plugins/terraform/package.json
+++ b/plugins/terraform/package.json
@@ -19,7 +19,11 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "frontend-plugin"
+    "role": "frontend-plugin",
+    "pluginId": "terraform",
+    "pluginPackages": [
+      "@globallogicuki/backstage-plugin-terraform"
+    ]
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
Fixes the "missing pluginId" error when the prepack command is run during publish workflow.