### PR TITLE
feat: adds ability to configure the page size param used when fetching data from Terraform

### DIFF
--- a/.changeset/late-lemons-own.md
+++ b/.changeset/late-lemons-own.md
@@ -1,0 +1,7 @@
+---
+'@globallogicuki/backstage-plugin-terraform-backend': minor
+---
+
+Allows overriding the page size in the API call to Terraform.
+
+This can be set in `app-config.yaml`.

--- a/plugins/terraform-backend/README.md
+++ b/plugins/terraform-backend/README.md
@@ -17,6 +17,7 @@ integrations:
   terraform:
     token: tokenGoesHere
     baseUrl: https://tfe.enterprise.com/api/v2 # Optional, for self-hosted TFE
+    pageSize: 20 # Optional, override default TF API page size
 ```
 
 ### New Backstage backend system

--- a/plugins/terraform-backend/src/lib/index.test.ts
+++ b/plugins/terraform-backend/src/lib/index.test.ts
@@ -168,12 +168,33 @@ describe('lib/index', () => {
     const token = 'token-1';
     const baseUrl = DEFAULT_TF_BASE_URL;
     const organization = 'org-1';
+    const pageSize = 7;
 
     it('should make the HTTP GET request correctly', async () => {
-      await listOrgRuns({ token, baseUrl, organization, workspaces });
+      await listOrgRuns({
+        token,
+        baseUrl,
+        organization,
+        workspaces,
+        pageSize,
+      });
 
       expect(axios.get).toHaveBeenCalledWith(
-        `${baseUrl}/api/v2/organizations/${organization}/runs?filter[workspace_names]=workspace-1,workspace-2`,
+        `${baseUrl}/api/v2/organizations/${organization}/runs?filter[workspace_names]=workspace-1,workspace-2&page[number]=1&page[size]=${pageSize}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+    });
+
+    it('should make the HTTP GET request correctly with default pageSize', async () => {
+      await listOrgRuns({
+        token,
+        baseUrl,
+        organization,
+        workspaces,
+      });
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${baseUrl}/api/v2/organizations/${organization}/runs?filter[workspace_names]=workspace-1,workspace-2&page[number]=1&page[size]=20`,
         { headers: { Authorization: `Bearer ${token}` } },
       );
     });

--- a/plugins/terraform-backend/src/lib/index.ts
+++ b/plugins/terraform-backend/src/lib/index.ts
@@ -74,14 +74,7 @@ type ListOrgRunsArgs = {
   token: string;
   organization: string;
   workspaces: string[];
-  latestOnly?: boolean;
-};
-
-type ListOrgWorkspacesArgs = {
-  baseUrl: string;
-  token: string;
-  organization: string;
-  workspaces: string[];
+  pageSize?: number;
 };
 
 export const listOrgRuns = async ({
@@ -89,12 +82,12 @@ export const listOrgRuns = async ({
   token,
   organization,
   workspaces,
-  latestOnly,
+  pageSize = 20,
 }: ListOrgRunsArgs) => {
   const url = new URL(
     `/api/v2/organizations/${organization}/runs?filter[workspace_names]=${workspaces.join(
       ',',
-    )}${latestOnly ? '&page[number]=1&page[size]=1' : ''}`,
+    )}${`&page[number]=1&page[size]=${pageSize}`}`,
     baseUrl,
   );
 
@@ -124,7 +117,7 @@ export const getLatestRunForWorkspaces = async (
     token,
     organization,
     workspaces,
-    latestOnly: true,
+    pageSize: 1,
   });
 
   return latestRun[0];
@@ -153,6 +146,13 @@ const fetchHealthAssessmentForWorkspace = async (
   );
 };
 
+type ListOrgWorkspacesArgs = {
+  baseUrl: string;
+  token: string;
+  organization: string;
+  workspaces: string[];
+};
+
 export const getAssessmentResultsForWorkspaces = async ({
   baseUrl,
   token,
@@ -172,11 +172,11 @@ export const getAssessmentResultsForWorkspaces = async ({
 
   const terraformWorkspaces: TerraformWorkspace[] = [];
   workspaces.forEach(w => {
-    const found = allWorkspacesForOrg.data.data.find(
+    const matchingWorkspace = allWorkspacesForOrg.data.data.find(
       f => f.attributes.name.toLowerCase() === w.toString().toLowerCase(),
     );
-    if (found !== undefined) {
-      terraformWorkspaces.push(found);
+    if (matchingWorkspace) {
+      terraformWorkspaces.push(matchingWorkspace);
     }
   });
 

--- a/plugins/terraform-backend/src/service/router.ts
+++ b/plugins/terraform-backend/src/service/router.ts
@@ -29,6 +29,7 @@ export async function createRouter(
   const baseUrl =
     config.getOptionalString('integrations.terraform.baseUrl') ??
     DEFAULT_TF_BASE_URL;
+  const pageSize = config.getOptionalNumber('integrations.terraform.pageSize');
 
   router.get(
     '/organizations/:orgName/workspaces/:workspaceNames/latestRun',
@@ -48,7 +49,7 @@ export async function createRouter(
       const organization = request.params.orgName;
       const workspaces = request.params.workspaceNames.split(',');
 
-      listOrgRuns({ token, baseUrl, organization, workspaces })
+      listOrgRuns({ token, baseUrl, organization, workspaces, pageSize })
         .then(runs => {
           response.json(runs);
         })


### PR DESCRIPTION
1. Reads `pageSize` from config, fallback to `20` if not set.
2. Removes the `latestOnly` arg and adds a `pageSize` arg.
3. Updates `getLatestRunForWorkspaces` to specify a `pageSize` of `1` to fetch the latest run instead of the removed `latestOnly` boolean.