### PR TITLE
fix(unleash): replace workspace protocol with explicit versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,13 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    [
+      "@globallogicuki/backstage-plugin-unleash",
+      "@globallogicuki/backstage-plugin-unleash-backend",
+      "@globallogicuki/backstage-plugin-unleash-common"
+    ]
+  ],
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",

--- a/.changeset/solid-cups-hammer.md
+++ b/.changeset/solid-cups-hammer.md
@@ -1,0 +1,7 @@
+---
+"@globallogicuki/backstage-plugin-unleash": patch
+"@globallogicuki/backstage-plugin-unleash-backend": patch
+"@globallogicuki/backstage-plugin-unleash-common": patch
+---
+
+Fixed npm install failure caused by `workspace:^` protocol in published packages. Replaced workspace protocol references with explicit version numbers to ensure packages can be installed from npm registry.

--- a/plugins/unleash-backend/package.json
+++ b/plugins/unleash-backend/package.json
@@ -80,7 +80,7 @@
     "@backstage/plugin-catalog-node": "^1.20.0",
     "@backstage/plugin-permission-common": "^0.9.3",
     "@backstage/plugin-permission-node": "^0.10.3",
-    "@globallogicuki/backstage-plugin-unleash-common": "workspace:^",
+    "@globallogicuki/backstage-plugin-unleash-common": "^0.1.2",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "node-fetch": "^2.6.7",

--- a/plugins/unleash/package.json
+++ b/plugins/unleash/package.json
@@ -58,7 +58,7 @@
     "@backstage/frontend-plugin-api": "^0.13.1",
     "@backstage/plugin-catalog-react": "^1.21.3",
     "@backstage/theme": "^0.7.0",
-    "@globallogicuki/backstage-plugin-unleash-common": "workspace:^",
+    "@globallogicuki/backstage-plugin-unleash-common": "^0.1.2",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5805,7 +5805,7 @@ __metadata:
     "@backstage/plugin-catalog-node": "npm:^1.20.0"
     "@backstage/plugin-permission-common": "npm:^0.9.3"
     "@backstage/plugin-permission-node": "npm:^0.10.3"
-    "@globallogicuki/backstage-plugin-unleash-common": "workspace:^"
+    "@globallogicuki/backstage-plugin-unleash-common": "npm:^0.1.2"
     "@types/express": "npm:^4.17.6"
     "@types/supertest": "npm:^2.0.12"
     express: "npm:^4.17.1"
@@ -5816,7 +5816,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@globallogicuki/backstage-plugin-unleash-common@workspace:^, @globallogicuki/backstage-plugin-unleash-common@workspace:plugins/unleash-common":
+"@globallogicuki/backstage-plugin-unleash-common@npm:^0.1.2, @globallogicuki/backstage-plugin-unleash-common@workspace:plugins/unleash-common":
   version: 0.0.0-use.local
   resolution: "@globallogicuki/backstage-plugin-unleash-common@workspace:plugins/unleash-common"
   dependencies:
@@ -5842,7 +5842,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:^1.21.3"
     "@backstage/test-utils": "npm:^1.7.13"
     "@backstage/theme": "npm:^0.7.0"
-    "@globallogicuki/backstage-plugin-unleash-common": "workspace:^"
+    "@globallogicuki/backstage-plugin-unleash-common": "npm:^0.1.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"


### PR DESCRIPTION
## Summary

Fixes npm install failure for Unleash plugin packages caused by `workspace:^` protocol not being resolved during publish.

## Problem

Users installing the Unleash plugins from npm were getting errors like:
```
workspace not found error on the unleash-common package
```

This happened because:
1. The `workspace:^` protocol in dependencies is a Yarn workspace feature
2. When `changeset publish` runs, it uses `npm publish` (not `yarn npm publish`)
3. `npm publish` doesn't understand `workspace:^` and publishes it literally
4. End users' package managers can't resolve `workspace:^`

## Solution

- Replaced `workspace:^` with explicit version `^0.1.2` in:
  - `plugins/unleash/package.json`
  - `plugins/unleash-backend/package.json`
- Added linked versioning in `.changeset/config.json` to keep all three Unleash packages in sync
- The `updateInternalDependencies: "patch"` setting will automatically update these version references on future releases

## Why Terraform plugin didn't have this issue

The Terraform plugins don't have a shared `-common` package - they're independent packages with no cross-dependencies using `workspace:^`.