### PR TITLE
refactor(unleash-backend): extract shared createAuditEvent helper

### DIFF
--- a/.changeset/tidy-audit-event-helper.md
+++ b/.changeset/tidy-audit-event-helper.md
@@ -1,0 +1,5 @@
+---
+'@globallogicuki/backstage-plugin-unleash-backend': patch
+---
+
+Refactor audit logging to use a shared `createAuditEvent` helper, removing duplicated credential resolution and event creation across the flag-toggle, variant-update, and strategy-update routes. No behavioural change.

--- a/plugins/unleash-backend/src/router.test.ts
+++ b/plugins/unleash-backend/src/router.test.ts
@@ -641,6 +641,127 @@ describe('createRouter', () => {
     });
   });
 
+  describe('Audit logging', () => {
+    beforeEach(() => {
+      mockCatalogApi.getEntities.mockResolvedValue({ items: [mockEntity] });
+      mockPermissions.authorize.mockResolvedValue([
+        { result: AuthorizeResult.ALLOW },
+      ]);
+    });
+
+    it('creates a flag-toggle audit event and marks it successful', async () => {
+      (toggleFeatureFlag as jest.Mock).mockResolvedValue(null);
+
+      const response = await request(app)
+        .post(
+          '/projects/test-project/features/test-flag/environments/development/on',
+        )
+        .set('Authorization', mockCredentials.user.header());
+
+      expect(response.status).toEqual(200);
+      expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: 'flag-toggle',
+          severityLevel: 'medium',
+          request: expect.anything(),
+          meta: expect.objectContaining({
+            featureName: 'test-flag',
+            action: 'on',
+            environment: 'development',
+            projectId: 'test-project',
+            userEntityRef: mockCredentials.user().principal.userEntityRef,
+          }),
+        }),
+      );
+      expect(mockAuditEvent.success).toHaveBeenCalledTimes(1);
+      expect(mockAuditEvent.fail).not.toHaveBeenCalled();
+    });
+
+    it('marks the audit event as failed when the toggle errors', async () => {
+      const serverError: any = new Error('Internal server error');
+      serverError.statusCode = 500;
+      (toggleFeatureFlag as jest.Mock).mockRejectedValue(serverError);
+
+      const response = await request(app)
+        .post(
+          '/projects/test-project/features/test-flag/environments/development/on',
+        )
+        .set('Authorization', mockCredentials.user.header());
+
+      expect(response.status).toEqual(500);
+      expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'flag-toggle' }),
+      );
+      expect(mockAuditEvent.fail).toHaveBeenCalledWith({ error: serverError });
+      expect(mockAuditEvent.success).not.toHaveBeenCalled();
+    });
+
+    it('creates a variant-update audit event and marks it successful', async () => {
+      (updateFeatureVariants as jest.Mock).mockResolvedValue({});
+
+      const response = await request(app)
+        .put('/projects/test-project/features/test-flag/variants')
+        .set('Authorization', mockCredentials.user.header())
+        .send([]);
+
+      expect(response.status).toEqual(200);
+      expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: 'variant-update',
+          severityLevel: 'medium',
+          meta: expect.objectContaining({
+            featureName: 'test-flag',
+            projectId: 'test-project',
+            userEntityRef: mockCredentials.user().principal.userEntityRef,
+          }),
+        }),
+      );
+      expect(mockAuditEvent.success).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a strategy-update audit event and marks it successful', async () => {
+      (updateStrategy as jest.Mock).mockResolvedValue({});
+
+      const response = await request(app)
+        .put(
+          '/projects/test-project/features/test-flag/environments/development/strategies/strat1',
+        )
+        .set('Authorization', mockCredentials.user.header())
+        .send({ name: 'default' });
+
+      expect(response.status).toEqual(200);
+      expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: 'strategy-update',
+          severityLevel: 'medium',
+          meta: expect.objectContaining({
+            featureName: 'test-flag',
+            strategyId: 'strat1',
+            environment: 'development',
+            projectId: 'test-project',
+            userEntityRef: mockCredentials.user().principal.userEntityRef,
+          }),
+        }),
+      );
+      expect(mockAuditEvent.success).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not create an audit event when permission is denied', async () => {
+      mockPermissions.authorize.mockResolvedValue([
+        { result: AuthorizeResult.DENY },
+      ]);
+
+      const response = await request(app)
+        .post(
+          '/projects/test-project/features/test-flag/environments/development/on',
+        )
+        .set('Authorization', mockCredentials.user.header());
+
+      expect(response.status).toEqual(403);
+      expect(mockAuditor.createEvent).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Strategy update non-editable environment', () => {
     beforeEach(() => {
       mockCatalogApi.getEntities.mockResolvedValue({ items: [mockEntity] });

--- a/plugins/unleash-backend/src/router.ts
+++ b/plugins/unleash-backend/src/router.ts
@@ -1,5 +1,6 @@
 import {
   AuditorService,
+  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
   PermissionsService,
@@ -147,6 +148,27 @@ export async function createRouter(
     return editableEnvs.length > 0 && editableEnvs.includes(environment);
   };
 
+  // Helper to resolve the calling user and create an audit event for a
+  // mutating operation. Returns the audit event (call success()/fail() on it)
+  // and the resolved userEntityRef for log enrichment.
+  const createAuditEvent = async (
+    req: express.Request,
+    eventId: string,
+    meta: Record<string, string>,
+  ): Promise<{ auditEvent: AuditorServiceEvent; userEntityRef: string }> => {
+    const credentials = await httpAuth.credentials(req, { allow: ['user'] });
+    const userEntityRef = credentials.principal.userEntityRef || 'unknown';
+
+    const auditEvent = await auditor.createEvent({
+      eventId,
+      severityLevel: 'medium',
+      request: req,
+      meta: { ...meta, userEntityRef },
+    });
+
+    return { auditEvent, userEntityRef };
+  };
+
   // Get configuration (including editable environments and numEnvs)
   router.get('/config', async (_req, res) => {
     return res.json({ editableEnvs, numEnvs });
@@ -232,21 +254,11 @@ export async function createRouter(
 
       logger.warn('[TOGGLE] ALLOWING - permission check passed');
 
-      const credentials = await httpAuth.credentials(req, { allow: ['user'] });
-      const userEntityRef = credentials.principal.userEntityRef || 'unknown';
-
-      const auditEvent = await auditor.createEvent({
-        eventId: 'flag-toggle',
-        severityLevel: 'medium',
-        request: req,
-        meta: {
-          featureName,
-          action,
-          environment,
-          projectId,
-          userEntityRef,
-        },
-      });
+      const { auditEvent, userEntityRef } = await createAuditEvent(
+        req,
+        'flag-toggle',
+        { featureName, action, environment, projectId },
+      );
 
       try {
         await toggleFeatureFlag(
@@ -311,19 +323,11 @@ export async function createRouter(
 
       const { projectId, featureName } = req.params;
 
-      const credentials = await httpAuth.credentials(req, { allow: ['user'] });
-      const userEntityRef = credentials.principal.userEntityRef || 'unknown';
-
-      const auditEvent = await auditor.createEvent({
-        eventId: 'variant-update',
-        severityLevel: 'medium',
-        request: req,
-        meta: {
-          featureName,
-          projectId,
-          userEntityRef,
-        },
-      });
+      const { auditEvent, userEntityRef } = await createAuditEvent(
+        req,
+        'variant-update',
+        { featureName, projectId },
+      );
 
       try {
         const data = await updateFeatureVariants(
@@ -404,21 +408,11 @@ export async function createRouter(
           .json({ error: 'Permission denied for strategy management' });
       }
 
-      const credentials = await httpAuth.credentials(req, { allow: ['user'] });
-      const userEntityRef = credentials.principal.userEntityRef || 'unknown';
-
-      const auditEvent = await auditor.createEvent({
-        eventId: 'strategy-update',
-        severityLevel: 'medium',
-        request: req,
-        meta: {
-          featureName,
-          strategyId,
-          environment,
-          projectId,
-          userEntityRef,
-        },
-      });
+      const { auditEvent, userEntityRef } = await createAuditEvent(
+        req,
+        'strategy-update',
+        { featureName, strategyId, environment, projectId },
+      );
 
       try {
         const data = await updateStrategy(


### PR DESCRIPTION
## What

Tidy-up of the audit logging added in v0.3.0. Extracts a single `createAuditEvent` helper inside `createRouter`, removing the duplicated credential-resolution + `auditor.createEvent` blocks that were copy-pasted across the **flag-toggle**, **variant-update**, and **strategy-update** routes.

No behavioural change — the helper produces identical `createEvent` calls (`severityLevel: 'medium'`, `request`, `meta` with `userEntityRef`) and the same `success()` / `fail()` lifecycle as before.

## Why

The v0.3.0 audit feature repeated the same ~15-line block three times. This consolidates it (net **43 fewer lines**) and gives us the version bump needed to re-publish — the original 0.3.0 publish failed on an expired NPM token, so we need a fresh version.

## Tests

Added a dedicated `Audit logging` describe block covering, for all three operations:
- `createEvent` is called with the correct `eventId`, `severityLevel`, and `meta` (incl. `userEntityRef`)
- `success()` fires on success
- `fail({ error })` fires on error (and not `success()`)
- **no** audit event is created when permission is denied

All 67 tests pass; `tsc`, `lint`, and `prettier --check` clean.

## Release

Changeset added (`patch` on `unleash-backend`). Due to the `fixed` versioning config, this bumps all three unleash packages to **0.3.1**. Merging to `main` triggers the Publish workflow, which will publish 0.3.1 (now that the NPM token is valid) — superseding the never-published 0.3.0.