### PR TITLE
feat: add skills-marketplace plugin

### DIFF
--- a/.changeset/add-skills-marketplace.md
+++ b/.changeset/add-skills-marketplace.md
@@ -1,0 +1,6 @@
+---
+'@globallogicuki/backstage-plugin-skills-marketplace': minor
+'@globallogicuki/backstage-plugin-skills-marketplace-backend': minor
+---
+
+Initial release of the Skills Marketplace plugin: a browsable, searchable page of shared Claude Code skills read from a Claude Code marketplace repo, with per-skill SKILL.md documentation and copy-able install commands. The backend reads the repo through Backstage's UrlReader and the standard `integrations` config, so GitHub, GitLab, and Bitbucket (cloud and self-hosted) work, including private repos. The frontend is styled entirely with the host app's default theme.

--- a/app-config.local.tpl.yaml
+++ b/app-config.local.tpl.yaml
@@ -3,6 +3,29 @@
 integrations:
   terraform:
     token: TOKEN_HERE
+  # If the skills marketplace repo is private, uncomment the credentials for
+  # its host — the skills-marketplace backend reads the repo through these
+  # integrations (same config the catalog uses). Public repos need nothing.
+  # github:
+  #   - host: github.com
+  #     token: GITHUB_TOKEN_HERE
+  # gitlab:
+  #   - host: gitlab.com
+  #     token: GITLAB_TOKEN_HERE
+  # bitbucketCloud:
+  #   - username: BITBUCKET_USERNAME_HERE
+  #     appPassword: BITBUCKET_APP_PASSWORD_HERE
+
+# The repo hosting the Claude Code marketplace shown on the /skills page.
+# Required by the skills-marketplace plugin — it has no defaults. Use the web
+# URL of the repo tree at the branch to read, e.g.
+#   https://github.com/ORG/REPO/tree/main
+#   https://gitlab.com/GROUP/REPO/-/tree/main
+#   https://bitbucket.org/WORKSPACE/REPO/src/main
+skillsMarketplace:
+  url: MARKETPLACE_TREE_URL
+  # URL format for the /plugin marketplace add install command shown to users.
+  # installUrlFormat: https # ssh (default) | https
 
 unleash:
   url: UNLEASH_URL

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,6 +40,7 @@
     "@backstage/plugin-techdocs-module-addons-contrib": "^1.1.39",
     "@backstage/plugin-user-settings": "^0.9.6",
     "@backstage/ui": "^0.17.1",
+    "@globallogicuki/backstage-plugin-skills-marketplace": "workspace:^",
     "@globallogicuki/backstage-plugin-terraform": "^0.11.7",
     "@globallogicuki/backstage-plugin-unleash": "workspace:^",
     "@material-ui/core": "^4.12.2",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { createApp } from '@backstage/frontend-defaults';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import skillsMarketplacePlugin from '@globallogicuki/backstage-plugin-skills-marketplace/alpha';
 import terraformPlugin from '@globallogicuki/backstage-plugin-terraform/alpha';
 import unleashPlugin from '@globallogicuki/backstage-plugin-unleash/alpha';
 import { navModule } from './modules/nav';
@@ -8,6 +9,7 @@ import { homeModule } from './modules/home';
 export default createApp({
   features: [
     catalogPlugin,
+    skillsMarketplacePlugin,
     terraformPlugin,
     unleashPlugin,
     navModule,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -46,6 +46,7 @@
     "@backstage/plugin-signals-backend": "^0.3.18",
     "@backstage/plugin-techdocs-backend": "^2.2.3",
     "@backstage/plugin-user-settings-backend": "^0.4.6",
+    "@globallogicuki/backstage-plugin-skills-marketplace-backend": "workspace:^",
     "@globallogicuki/backstage-plugin-terraform-backend": "^0.10.6",
     "@globallogicuki/backstage-plugin-unleash-backend": "workspace:^",
     "app": "link:../app",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -64,6 +64,11 @@ backend.add(import('@backstage/plugin-user-settings-backend'));
 // terraform plugin
 backend.add(import('@globallogicuki/backstage-plugin-terraform-backend'));
 
+// skills marketplace plugin
+backend.add(
+  import('@globallogicuki/backstage-plugin-skills-marketplace-backend'),
+);
+
 // notifications and signals plugins
 backend.add(import('@backstage/plugin-notifications-backend'));
 backend.add(import('@backstage/plugin-signals-backend'));

--- a/plugins/skills-marketplace-backend/.eslintrc.js
+++ b/plugins/skills-marketplace-backend/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/skills-marketplace-backend/README.md
+++ b/plugins/skills-marketplace-backend/README.md
@@ -1,0 +1,41 @@
+# Skill Marketplace Backend
+
+Backend for the
+[Skill Marketplace](https://github.com/globallogicuki/globallogic-backstage-plugins/tree/main/plugins/skills-marketplace)
+frontend plugin. It reads a Claude Code marketplace repo (a repo containing
+`.claude-plugin/marketplace.json`) through Backstage's `UrlReader` and the
+standard [`integrations`](https://backstage.io/docs/integrations/)
+configuration, so GitHub, GitLab, and Bitbucket — cloud or self-hosted,
+public or private — all work with no plugin-specific credentials. Responses
+are cached for five minutes to protect API rate limits.
+
+## Endpoints
+
+- `GET /api/skills-marketplace/marketplace` — the parsed marketplace manifest
+  plus the repo's derived SSH clone URL.
+- `GET /api/skills-marketplace/skill-doc?source=./skills/foo` — the raw
+  `SKILL.md` for one skill (404 when the skill does not provide one).
+
+## Installation
+
+```sh
+yarn --cwd packages/backend add @globallogicuki/backstage-plugin-skills-marketplace-backend
+```
+
+Register it in `packages/backend/src/index.ts`:
+
+```ts
+backend.add(
+  import('@globallogicuki/backstage-plugin-skills-marketplace-backend'),
+);
+```
+
+## Configuration
+
+```yaml
+skillsMarketplace:
+  url: https://github.com/my-org/skills-marketplace/tree/main
+```
+
+See the frontend plugin's README for the full configuration reference,
+including private repos and self-hosted providers.

--- a/plugins/skills-marketplace-backend/README.md
+++ b/plugins/skills-marketplace-backend/README.md
@@ -2,19 +2,17 @@
 
 Backend for the
 [Skill Marketplace](https://github.com/globallogicuki/globallogic-backstage-plugins/tree/main/plugins/skills-marketplace)
-frontend plugin. It reads a Claude Code marketplace repo (a repo containing
-`.claude-plugin/marketplace.json`) through Backstage's `UrlReader` and the
-standard [`integrations`](https://backstage.io/docs/integrations/)
-configuration, so GitHub, GitLab, and Bitbucket — cloud or self-hosted,
-public or private — all work with no plugin-specific credentials. Responses
-are cached for five minutes to protect API rate limits.
+plugin. Reads the marketplace repo via Backstage's `UrlReader` and the standard
+[`integrations`](https://backstage.io/docs/integrations/) config — GitHub,
+GitLab, and Bitbucket, public or private, cloud or self-hosted. Responses are
+cached for five minutes.
 
 ## Endpoints
 
-- `GET /api/skills-marketplace/marketplace` — the parsed marketplace manifest
-  plus the repo's derived SSH clone URL.
+- `GET /api/skills-marketplace/marketplace` — the marketplace manifest plus
+  the derived git install URL.
 - `GET /api/skills-marketplace/skill-doc?source=./skills/foo` — the raw
-  `SKILL.md` for one skill (404 when the skill does not provide one).
+  `SKILL.md` for one skill (404 when the skill has none).
 
 ## Installation
 
@@ -22,9 +20,8 @@ are cached for five minutes to protect API rate limits.
 yarn --cwd packages/backend add @globallogicuki/backstage-plugin-skills-marketplace-backend
 ```
 
-Register it in `packages/backend/src/index.ts`:
-
 ```ts
+// packages/backend/src/index.ts
 backend.add(
   import('@globallogicuki/backstage-plugin-skills-marketplace-backend'),
 );
@@ -35,7 +32,8 @@ backend.add(
 ```yaml
 skillsMarketplace:
   url: https://github.com/my-org/skills-marketplace/tree/main
+  installUrlFormat: https # optional: ssh (default) | https
 ```
 
-See the frontend plugin's README for the full configuration reference,
-including private repos and self-hosted providers.
+See the frontend plugin's README for the full reference, including private
+repos.

--- a/plugins/skills-marketplace-backend/config.d.ts
+++ b/plugins/skills-marketplace-backend/config.d.ts
@@ -1,0 +1,24 @@
+export interface Config {
+  /**
+   * Configuration for the Skills Marketplace plugin. Required for the plugin
+   * to load skills — there are no built-in defaults.
+   */
+  skillsMarketplace?: {
+    /**
+     * Web URL of the marketplace repo tree at the branch to read — the URL
+     * you see in the browser when viewing the repo at a branch, e.g.
+     * `https://github.com/my-org/skills-marketplace/tree/main`,
+     * `https://gitlab.com/my-group/skills-marketplace/-/tree/main`, or
+     * `https://bitbucket.org/my-workspace/skills-marketplace/src/main`.
+     * Private repos are read with the credentials configured under
+     * `integrations.*`.
+     */
+    url: string;
+    /**
+     * URL format for the `/plugin marketplace add` install command shown to
+     * users: `ssh` (`git@host:owner/repo.git`, the default) or `https`
+     * (`https://host/owner/repo.git`).
+     */
+    installUrlFormat?: 'ssh' | 'https';
+  };
+}

--- a/plugins/skills-marketplace-backend/package.json
+++ b/plugins/skills-marketplace-backend/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@globallogicuki/backstage-plugin-skills-marketplace-backend",
+  "description": "Backend for the Skills Marketplace plugin: reads Claude Code marketplace repos via Backstage integrations, including private repos.",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/globallogicuki/globallogic-backstage-plugins/tree/main/plugins/skills-marketplace-backend",
+  "bugs": {
+    "url": "https://github.com/globallogicuki/globallogic-backstage-plugins/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:globallogicuki/globallogic-backstage-plugins",
+    "directory": "plugins/skills-marketplace-backend"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin",
+    "pluginId": "skills-marketplace",
+    "pluginPackages": [
+      "@globallogicuki/backstage-plugin-skills-marketplace",
+      "@globallogicuki/backstage-plugin-skills-marketplace-backend"
+    ]
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "^1.10.0",
+    "@backstage/errors": "^1.3.1",
+    "@backstage/integration": "^2.1.0",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.0"
+  },
+  "devDependencies": {
+    "@backstage/backend-test-utils": "^1.11.6",
+    "@backstage/cli": "^0.36.5",
+    "@types/express": "^4.17.6",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^6.3.4"
+  },
+  "files": [
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
+}

--- a/plugins/skills-marketplace-backend/src/index.ts
+++ b/plugins/skills-marketplace-backend/src/index.ts
@@ -1,0 +1,2 @@
+export * from './service/router';
+export { skillsMarketplacePlugin as default } from './plugin';

--- a/plugins/skills-marketplace-backend/src/lib/repo.test.ts
+++ b/plugins/skills-marketplace-backend/src/lib/repo.test.ts
@@ -1,0 +1,43 @@
+import { deriveInstallUrl } from './repo';
+
+describe('deriveInstallUrl', () => {
+  it.each([
+    [
+      'https://github.com/my-org/skills-marketplace/tree/main',
+      'git@github.com:my-org/skills-marketplace.git',
+    ],
+    [
+      'https://gitlab.com/my-group/sub-group/skills-marketplace/-/tree/main',
+      'git@gitlab.com:my-group/sub-group/skills-marketplace.git',
+    ],
+    [
+      'https://bitbucket.org/my-workspace/skills-marketplace/src/main',
+      'git@bitbucket.org:my-workspace/skills-marketplace.git',
+    ],
+    [
+      'https://github.com/my-org/skills-marketplace',
+      'git@github.com:my-org/skills-marketplace.git',
+    ],
+  ])('derives the SSH install URL from %s', (treeUrl, expected) => {
+    expect(deriveInstallUrl(treeUrl)).toBe(expected);
+  });
+
+  it.each([
+    [
+      'https://github.com/my-org/skills-marketplace/tree/main',
+      'https://github.com/my-org/skills-marketplace.git',
+    ],
+    [
+      'https://bitbucket.org/my-workspace/skills-marketplace/src/main',
+      'https://bitbucket.org/my-workspace/skills-marketplace.git',
+    ],
+  ])('derives the https install URL from %s', (treeUrl, expected) => {
+    expect(deriveInstallUrl(treeUrl, 'https')).toBe(expected);
+  });
+
+  it('throws when the URL has no repo path', () => {
+    expect(() => deriveInstallUrl('https://github.com/only-org')).toThrow(
+      /Cannot derive a repo path/,
+    );
+  });
+});

--- a/plugins/skills-marketplace-backend/src/lib/repo.ts
+++ b/plugins/skills-marketplace-backend/src/lib/repo.ts
@@ -1,10 +1,6 @@
 import { ScmIntegrations } from '@backstage/integration';
 
-/**
- * Resolve a path within the marketplace repo against the configured tree URL,
- * in a provider-aware way (via the same resolution the catalog uses for
- * relative locations).
- */
+/** Resolve a repo-relative path against the configured tree URL. */
 export function resolveFileUrl(
   integrations: ScmIntegrations,
   treeUrl: string,

--- a/plugins/skills-marketplace-backend/src/lib/repo.ts
+++ b/plugins/skills-marketplace-backend/src/lib/repo.ts
@@ -1,0 +1,48 @@
+import { ScmIntegrations } from '@backstage/integration';
+
+/**
+ * Resolve a path within the marketplace repo against the configured tree URL,
+ * in a provider-aware way (via the same resolution the catalog uses for
+ * relative locations).
+ */
+export function resolveFileUrl(
+  integrations: ScmIntegrations,
+  treeUrl: string,
+  path: string,
+): string {
+  const base = treeUrl.endsWith('/') ? treeUrl : `${treeUrl}/`;
+  const clean = path.replace(/^\.?\//, '');
+  return integrations.resolveUrl({ url: clean, base });
+}
+
+// Branch markers in repo web URLs: GitLab's /-/tree|blob/, and the plain
+// /tree|blob|src/ used by GitHub and Bitbucket Cloud.
+const BRANCH_MARKER = /\/(?:-\/)?(?:tree|blob|src)\/.*$/;
+
+/** URL format for the marketplace install command. */
+export type InstallUrlFormat = 'ssh' | 'https';
+
+/**
+ * Derive the git URL for the install command from the configured tree URL,
+ * e.g. `https://github.com/my-org/repo/tree/main` →
+ * `git@github.com:my-org/repo.git` (ssh) or
+ * `https://github.com/my-org/repo.git` (https).
+ */
+export function deriveInstallUrl(
+  treeUrl: string,
+  format: InstallUrlFormat = 'ssh',
+): string {
+  const { host, pathname } = new URL(treeUrl);
+  const repoPath = pathname
+    .replace(BRANCH_MARKER, '')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/, '');
+  if (!repoPath || !repoPath.includes('/')) {
+    throw new Error(
+      `Cannot derive a repo path from skillsMarketplace.url '${treeUrl}'`,
+    );
+  }
+  return format === 'https'
+    ? `https://${host}/${repoPath}.git`
+    : `git@${host}:${repoPath}.git`;
+}

--- a/plugins/skills-marketplace-backend/src/plugin.test.ts
+++ b/plugins/skills-marketplace-backend/src/plugin.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { skillsMarketplacePlugin } from './plugin';
+
+describe('skillsMarketplacePlugin', () => {
+  it('serves the marketplace endpoint', async () => {
+    const manifest = {
+      name: 'my-marketplace',
+      plugins: [
+        { name: 'foo', source: './skills/foo', description: 'Foo skill' },
+      ],
+    };
+    const { server } = await startTestBackend({
+      features: [
+        skillsMarketplacePlugin,
+        mockServices.rootConfig.factory({
+          data: {
+            skillsMarketplace: {
+              url: 'https://github.com/my-org/skills-marketplace/tree/main',
+            },
+          },
+        }),
+        mockServices.urlReader.mock({
+          readUrl: async () =>
+            ({
+              buffer: async () => Buffer.from(JSON.stringify(manifest), 'utf8'),
+            } as any),
+        }).factory,
+      ],
+    });
+
+    const response = await request(server).get(
+      '/api/skills-marketplace/marketplace',
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      marketplace: manifest,
+      installUrl: 'git@github.com:my-org/skills-marketplace.git',
+    });
+  });
+});

--- a/plugins/skills-marketplace-backend/src/plugin.ts
+++ b/plugins/skills-marketplace-backend/src/plugin.ts
@@ -1,0 +1,35 @@
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+import { createRouter } from './service/router';
+
+/**
+ * skillsMarketplacePlugin backend plugin
+ *
+ * @public
+ */
+export const skillsMarketplacePlugin = createBackendPlugin({
+  pluginId: 'skills-marketplace',
+  register(env) {
+    env.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+        config: coreServices.rootConfig,
+        urlReader: coreServices.urlReader,
+        cache: coreServices.cache,
+      },
+      async init({ httpRouter, logger, config, urlReader, cache }) {
+        httpRouter.use(
+          await createRouter({
+            logger,
+            config,
+            urlReader,
+            cache,
+          }),
+        );
+      },
+    });
+  },
+});

--- a/plugins/skills-marketplace-backend/src/service/router.test.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.test.ts
@@ -4,22 +4,23 @@ import { NotFoundError } from '@backstage/errors';
 import { mockServices } from '@backstage/backend-test-utils';
 import { createRouter } from './router';
 
-const TREE_URL = 'https://bitbucket.org/my-workspace/skills-marketplace/src/main';
+const TREE_URL =
+  'https://bitbucket.org/my-workspace/skills-marketplace/src/main';
 
 const manifest = {
   name: 'my-marketplace',
-  plugins: [
-    { name: 'foo', source: './skills/foo', description: 'Foo skill' },
-  ],
+  plugins: [{ name: 'foo', source: './skills/foo', description: 'Foo skill' }],
 };
 
 describe('createRouter', () => {
   const readUrl = jest.fn();
   let app: express.Express;
 
-  const buildApp = async (configData: object = {
-    skillsMarketplace: { url: TREE_URL },
-  }) => {
+  const buildApp = async (
+    configData: object = {
+      skillsMarketplace: { url: TREE_URL },
+    },
+  ) => {
     const router = await createRouter({
       logger: mockServices.logger.mock(),
       config: mockServices.rootConfig({ data: configData }),

--- a/plugins/skills-marketplace-backend/src/service/router.test.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.test.ts
@@ -1,0 +1,157 @@
+import express from 'express';
+import request from 'supertest';
+import { NotFoundError } from '@backstage/errors';
+import { mockServices } from '@backstage/backend-test-utils';
+import { createRouter } from './router';
+
+const TREE_URL = 'https://bitbucket.org/my-workspace/skills-marketplace/src/main';
+
+const manifest = {
+  name: 'my-marketplace',
+  plugins: [
+    { name: 'foo', source: './skills/foo', description: 'Foo skill' },
+  ],
+};
+
+describe('createRouter', () => {
+  const readUrl = jest.fn();
+  let app: express.Express;
+
+  const buildApp = async (configData: object = {
+    skillsMarketplace: { url: TREE_URL },
+  }) => {
+    const router = await createRouter({
+      logger: mockServices.logger.mock(),
+      config: mockServices.rootConfig({ data: configData }),
+      urlReader: { readUrl } as any,
+      cache: mockServices.cache.mock({
+        get: async () => undefined,
+        set: async () => {},
+      }),
+    });
+    const instance = express();
+    instance.use(router);
+    return instance;
+  };
+
+  const readUrlResponse = (content: string) => ({
+    buffer: async () => Buffer.from(content, 'utf8'),
+  });
+
+  beforeEach(async () => {
+    readUrl.mockReset();
+    app = await buildApp();
+  });
+
+  describe('GET /marketplace', () => {
+    it('returns the manifest and derived SSH install URL', async () => {
+      readUrl.mockResolvedValue(readUrlResponse(JSON.stringify(manifest)));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        marketplace: manifest,
+        installUrl: 'git@bitbucket.org:my-workspace/skills-marketplace.git',
+      });
+      expect(readUrl).toHaveBeenCalledWith(
+        `${TREE_URL}/.claude-plugin/marketplace.json`,
+      );
+    });
+
+    it('derives an https install URL when configured', async () => {
+      app = await buildApp({
+        skillsMarketplace: { url: TREE_URL, installUrlFormat: 'https' },
+      });
+      readUrl.mockResolvedValue(readUrlResponse(JSON.stringify(manifest)));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(200);
+      expect(response.body.installUrl).toEqual(
+        'https://bitbucket.org/my-workspace/skills-marketplace.git',
+      );
+    });
+
+    it('rejects an unsupported installUrlFormat', async () => {
+      app = await buildApp({
+        skillsMarketplace: { url: TREE_URL, installUrlFormat: 'ftp' },
+      });
+      readUrl.mockResolvedValue(readUrlResponse(JSON.stringify(manifest)));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(500);
+      expect(response.body.error.message).toMatch(/invalid installUrlFormat/);
+    });
+
+    it('returns 404 when the manifest does not exist', async () => {
+      readUrl.mockRejectedValue(new NotFoundError('nope'));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(404);
+      expect(response.body.error.message).toMatch(/No .*marketplace.json/);
+    });
+
+    it('returns 502 when the manifest has no plugins array', async () => {
+      readUrl.mockResolvedValue(readUrlResponse(JSON.stringify({ name: 'x' })));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(502);
+      expect(response.body.error.message).toMatch(/plugins/);
+    });
+
+    it('returns 500 with guidance when unconfigured', async () => {
+      app = await buildApp({});
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(500);
+      expect(response.body.error.message).toMatch(
+        /Skills Marketplace is not configured/,
+      );
+    });
+  });
+
+  describe('GET /skill-doc', () => {
+    it('returns the SKILL.md content', async () => {
+      readUrl.mockResolvedValue(readUrlResponse('---\nname: foo\n---\nBody'));
+
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/foo' });
+
+      expect(response.status).toEqual(200);
+      expect(response.text).toEqual('---\nname: foo\n---\nBody');
+      expect(readUrl).toHaveBeenCalledWith(`${TREE_URL}/skills/foo/SKILL.md`);
+    });
+
+    it('returns 404 when the skill has no SKILL.md', async () => {
+      readUrl.mockRejectedValue(new NotFoundError('nope'));
+
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/foo' });
+
+      expect(response.status).toEqual(404);
+    });
+
+    it('rejects a missing or traversal source', async () => {
+      const missing = await request(app).get('/skill-doc');
+      expect(missing.status).toEqual(400);
+
+      const traversal = await request(app)
+        .get('/skill-doc')
+        .query({ source: '../secrets' });
+      expect(traversal.status).toEqual(400);
+
+      const absolute = await request(app)
+        .get('/skill-doc')
+        .query({ source: 'https://evil.example/x' });
+      expect(absolute.status).toEqual(400);
+      expect(readUrl).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/skills-marketplace-backend/src/service/router.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.ts
@@ -97,7 +97,9 @@ export async function createRouter(
     }
     if (!Array.isArray(marketplace.plugins)) {
       res.status(502).json({
-        error: { message: 'Marketplace manifest is missing a "plugins" array.' },
+        error: {
+          message: 'Marketplace manifest is missing a "plugins" array.',
+        },
       });
       return;
     }

--- a/plugins/skills-marketplace-backend/src/service/router.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.ts
@@ -1,0 +1,150 @@
+import express from 'express';
+import Router from 'express-promise-router';
+import { NotFoundError } from '@backstage/errors';
+import { ScmIntegrations } from '@backstage/integration';
+import {
+  CacheService,
+  LoggerService,
+  RootConfigService,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
+import {
+  InstallUrlFormat,
+  deriveInstallUrl,
+  resolveFileUrl,
+} from '../lib/repo';
+
+export interface RouterOptions {
+  logger: LoggerService;
+  config: RootConfigService;
+  urlReader: UrlReaderService;
+  cache: CacheService;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Repo-relative skill source as declared in the manifest, e.g.
+// `./skills/deck-gl`. No absolute URLs, no parent traversal.
+const SAFE_SOURCE = /^\.?\/?[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+const isNotFound = (error: unknown): boolean =>
+  error instanceof NotFoundError ||
+  (error instanceof Error && error.name === 'NotFoundError');
+
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const { logger, config, urlReader, cache } = options;
+  const integrations = ScmIntegrations.fromConfig(config);
+
+  const readFile = async (treeUrl: string, path: string): Promise<string> => {
+    const url = resolveFileUrl(integrations, treeUrl, path);
+    const cached = await cache.get<string>(url);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const response = await urlReader.readUrl(url);
+    const content = (await response.buffer()).toString('utf8');
+    await cache.set(url, content, { ttl: CACHE_TTL_MS });
+    return content;
+  };
+
+  const getTreeUrl = (): string => {
+    const treeUrl = config.getOptionalString('skillsMarketplace.url');
+    if (!treeUrl) {
+      throw new Error(
+        'Skills Marketplace is not configured: set skillsMarketplace.url in ' +
+          'app-config.yaml to the web URL of the repo tree that hosts your ' +
+          'Claude Code marketplace, e.g. ' +
+          'https://github.com/my-org/skills-marketplace/tree/main',
+      );
+    }
+    return treeUrl;
+  };
+
+  const getInstallUrlFormat = (): InstallUrlFormat => {
+    const format =
+      config.getOptionalString('skillsMarketplace.installUrlFormat') ?? 'ssh';
+    if (format !== 'ssh' && format !== 'https') {
+      throw new Error(
+        `Skills Marketplace: invalid installUrlFormat '${format}'. ` +
+          `Supported values: ssh, https.`,
+      );
+    }
+    return format;
+  };
+
+  const router = Router();
+  router.use(express.json());
+
+  router.get('/marketplace', async (_req, res) => {
+    const treeUrl = getTreeUrl();
+    let marketplace;
+    try {
+      marketplace = JSON.parse(
+        await readFile(treeUrl, '.claude-plugin/marketplace.json'),
+      );
+    } catch (error) {
+      if (isNotFound(error)) {
+        res.status(404).json({
+          error: {
+            message: `No .claude-plugin/marketplace.json found at ${treeUrl}.`,
+          },
+        });
+        return;
+      }
+      throw error;
+    }
+    if (!Array.isArray(marketplace.plugins)) {
+      res.status(502).json({
+        error: { message: 'Marketplace manifest is missing a "plugins" array.' },
+      });
+      return;
+    }
+    res.json({
+      marketplace,
+      installUrl: deriveInstallUrl(treeUrl, getInstallUrlFormat()),
+    });
+  });
+
+  router.get('/skill-doc', async (req, res) => {
+    const source = req.query.source;
+    if (typeof source !== 'string' || !SAFE_SOURCE.test(source)) {
+      res.status(400).json({
+        error: { message: 'Invalid "source" query parameter.' },
+      });
+      return;
+    }
+    const treeUrl = getTreeUrl();
+    try {
+      const content = await readFile(treeUrl, `${source}/SKILL.md`);
+      res.type('text/markdown').send(content);
+    } catch (error) {
+      if (isNotFound(error)) {
+        res.status(404).json({
+          error: { message: `No SKILL.md found for ${source}.` },
+        });
+        return;
+      }
+      throw error;
+    }
+  });
+
+  router.use(
+    (
+      error: Error,
+      _req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (res.headersSent) {
+        next(error);
+        return;
+      }
+      logger.error(`Skills Marketplace request failed: ${error.message}`);
+      res.status(500).json({ error: { message: error.message } });
+    },
+  );
+
+  return router;
+}

--- a/plugins/skills-marketplace/.eslintrc.js
+++ b/plugins/skills-marketplace/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/skills-marketplace/README.md
+++ b/plugins/skills-marketplace/README.md
@@ -1,36 +1,20 @@
 # Skill Marketplace
 
-A Backstage plugin that surfaces shared **Claude Code skills** — read from a
+Browse and install shared **Claude Code skills** from a
 [Claude Code marketplace](https://docs.anthropic.com/en/docs/claude-code) repo
-on GitHub, GitLab, or Bitbucket — as a browsable, searchable marketplace
-inside Backstage.
+(a repo containing `.claude-plugin/marketplace.json`) inside Backstage.
 
-## What it does
-
-- Reads the `.claude-plugin/marketplace.json` manifest from the marketplace
-  repo and renders each skill as a card (name, description, category,
-  keywords).
-- Full-text search plus one-click category filtering.
-- Click a card to open a side drawer with the skill's rendered `SKILL.md`
-  documentation and copy-able install commands for Claude Code:
-
-  ```
-  /plugin marketplace add git@<host>:<owner>/<repo>.git
-  /plugin install <skill-name>@<marketplace-name>
-  ```
-
-The repo is read server-side by the companion backend plugin
-(`@globallogicuki/backstage-plugin-skills-marketplace-backend`) through
-Backstage's `UrlReader` and your existing `integrations` configuration — so
-private repos and self-hosted providers work with no extra plumbing, and
-responses are cached to protect API rate limits. The frontend uses the host
-app's theme throughout — standard Material UI cards, chips and drawer — so it
-looks native in any Backstage instance.
+- Skill cards with name, description, category, and keywords; full-text search
+  and category filtering.
+- A detail drawer with the skill's rendered `SKILL.md` and copy-able Claude
+  Code install commands.
+- The repo is read server-side by
+  `@globallogicuki/backstage-plugin-skills-marketplace-backend` via Backstage's
+  `UrlReader`, so GitHub, GitLab, and Bitbucket all work — public or private,
+  cloud or self-hosted.
+- Uses the host app's default theme throughout.
 
 ## Installation
-
-Add the frontend plugin to `packages/app` and the backend plugin to
-`packages/backend`:
 
 ```sh
 yarn --cwd packages/app add @globallogicuki/backstage-plugin-skills-marketplace
@@ -47,24 +31,18 @@ backend.add(
 
 ### New frontend system
 
-Register the plugin in `packages/app/src/App.tsx`:
-
 ```tsx
+// packages/app/src/App.tsx
 import skillsMarketplacePlugin from '@globallogicuki/backstage-plugin-skills-marketplace/alpha';
 
 export default createApp({
-  features: [
-    // ...other features
-    skillsMarketplacePlugin,
-  ],
+  features: [skillsMarketplacePlugin],
 });
 ```
 
-The plugin registers a page at `/skills` with a sidebar nav item.
+This registers a `/skills` page with a sidebar nav item.
 
 ### Classic frontend system
-
-Register the API factory and page route in `packages/app`:
 
 ```tsx
 import {
@@ -73,7 +51,7 @@ import {
   skillsMarketplaceApiRef,
 } from '@globallogicuki/backstage-plugin-skills-marketplace';
 
-// in packages/app/src/apis.ts
+// packages/app/src/apis.ts
 createApiFactory({
   api: skillsMarketplaceApiRef,
   deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
@@ -83,20 +61,15 @@ createApiFactory({
 
 // inside <FlatRoutes>
 <Route path="/skills" element={<SkillsMarketplacePage />} />;
-```
 
-And add a sidebar entry in `packages/app/src/components/Root/Root.tsx`:
-
-```tsx
-<SidebarItem icon={StorefrontIcon} to="skills" text="Skills" />
+// packages/app/src/components/Root/Root.tsx
+<SidebarItem icon={StorefrontIcon} to="skills" text="Skills" />;
 ```
 
 ## Configuration
 
-Point the plugin at your marketplace repo in `app-config.yaml` — this is
-required, there are no built-in defaults. Use the web URL of the repo tree at
-the branch to read (the URL you see in the browser when viewing the repo at a
-branch):
+Required — there are no defaults. `url` is the web URL of the repo tree at the
+branch to read:
 
 ```yaml
 skillsMarketplace:
@@ -104,25 +77,21 @@ skillsMarketplace:
   installUrlFormat: https # optional: ssh (default) | https
 ```
 
-Equivalent `url` forms for the other providers:
+Other providers:
 
 ```
 https://gitlab.com/my-group/skills-marketplace/-/tree/main
 https://bitbucket.org/my-workspace/skills-marketplace/src/main
 ```
 
-`installUrlFormat` controls the git URL shown in the
-`/plugin marketplace add` install command: `ssh` (the default,
-`git@host:owner/repo.git`) or `https` (`https://host/owner/repo.git`).
-Without configuration the page shows an error explaining what to set.
+`installUrlFormat` sets the git URL shown in the `/plugin marketplace add`
+command: `git@host:owner/repo.git` (ssh) or `https://host/owner/repo.git`.
 
-### Private repos and self-hosted providers
+### Private repos
 
-The backend reads the repo with Backstage's `UrlReader`, which resolves hosts
-and credentials from your standard
-[`integrations`](https://backstage.io/docs/integrations/) configuration — the
-same one the catalog uses. A public repo needs nothing. For a private repo,
-add (or reuse) the credentials for its host:
+Add credentials for the repo's host under
+[`integrations`](https://backstage.io/docs/integrations/) — the same config
+the catalog uses. Public repos need nothing.
 
 ```yaml
 integrations:
@@ -133,10 +102,9 @@ integrations:
     - host: gitlab.com
       token: ${GITLAB_TOKEN}
   bitbucketCloud:
-    - username: ${BITBUCKET_USERNAME}
-      appPassword: ${BITBUCKET_APP_PASSWORD}
+    - username: ${BITBUCKET_USERNAME} # Atlassian account email
+      appPassword: ${BITBUCKET_API_TOKEN} # scoped API token with repository read
 ```
 
-Self-hosted GitHub Enterprise, GitLab, and Bitbucket Server instances work the
-same way — declare the host under `integrations` and use its web URL in
-`skillsMarketplace.url`.
+Self-hosted instances work the same way: declare the host under `integrations`
+and use its web URL in `skillsMarketplace.url`.

--- a/plugins/skills-marketplace/README.md
+++ b/plugins/skills-marketplace/README.md
@@ -1,0 +1,142 @@
+# Skill Marketplace
+
+A Backstage plugin that surfaces shared **Claude Code skills** — read from a
+[Claude Code marketplace](https://docs.anthropic.com/en/docs/claude-code) repo
+on GitHub, GitLab, or Bitbucket — as a browsable, searchable marketplace
+inside Backstage.
+
+## What it does
+
+- Reads the `.claude-plugin/marketplace.json` manifest from the marketplace
+  repo and renders each skill as a card (name, description, category,
+  keywords).
+- Full-text search plus one-click category filtering.
+- Click a card to open a side drawer with the skill's rendered `SKILL.md`
+  documentation and copy-able install commands for Claude Code:
+
+  ```
+  /plugin marketplace add git@<host>:<owner>/<repo>.git
+  /plugin install <skill-name>@<marketplace-name>
+  ```
+
+The repo is read server-side by the companion backend plugin
+(`@globallogicuki/backstage-plugin-skills-marketplace-backend`) through
+Backstage's `UrlReader` and your existing `integrations` configuration — so
+private repos and self-hosted providers work with no extra plumbing, and
+responses are cached to protect API rate limits. The frontend uses the host
+app's theme throughout — standard Material UI cards, chips and drawer — so it
+looks native in any Backstage instance.
+
+## Installation
+
+Add the frontend plugin to `packages/app` and the backend plugin to
+`packages/backend`:
+
+```sh
+yarn --cwd packages/app add @globallogicuki/backstage-plugin-skills-marketplace
+yarn --cwd packages/backend add @globallogicuki/backstage-plugin-skills-marketplace-backend
+```
+
+Register the backend in `packages/backend/src/index.ts`:
+
+```ts
+backend.add(
+  import('@globallogicuki/backstage-plugin-skills-marketplace-backend'),
+);
+```
+
+### New frontend system
+
+Register the plugin in `packages/app/src/App.tsx`:
+
+```tsx
+import skillsMarketplacePlugin from '@globallogicuki/backstage-plugin-skills-marketplace/alpha';
+
+export default createApp({
+  features: [
+    // ...other features
+    skillsMarketplacePlugin,
+  ],
+});
+```
+
+The plugin registers a page at `/skills` with a sidebar nav item.
+
+### Classic frontend system
+
+Register the API factory and page route in `packages/app`:
+
+```tsx
+import {
+  SkillsMarketplacePage,
+  SkillsMarketplaceClient,
+  skillsMarketplaceApiRef,
+} from '@globallogicuki/backstage-plugin-skills-marketplace';
+
+// in packages/app/src/apis.ts
+createApiFactory({
+  api: skillsMarketplaceApiRef,
+  deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+  factory: ({ discoveryApi, fetchApi }) =>
+    new SkillsMarketplaceClient({ discoveryApi, fetchApi }),
+});
+
+// inside <FlatRoutes>
+<Route path="/skills" element={<SkillsMarketplacePage />} />;
+```
+
+And add a sidebar entry in `packages/app/src/components/Root/Root.tsx`:
+
+```tsx
+<SidebarItem icon={StorefrontIcon} to="skills" text="Skills" />
+```
+
+## Configuration
+
+Point the plugin at your marketplace repo in `app-config.yaml` — this is
+required, there are no built-in defaults. Use the web URL of the repo tree at
+the branch to read (the URL you see in the browser when viewing the repo at a
+branch):
+
+```yaml
+skillsMarketplace:
+  url: https://github.com/my-org/skills-marketplace/tree/main
+  installUrlFormat: https # optional: ssh (default) | https
+```
+
+Equivalent `url` forms for the other providers:
+
+```
+https://gitlab.com/my-group/skills-marketplace/-/tree/main
+https://bitbucket.org/my-workspace/skills-marketplace/src/main
+```
+
+`installUrlFormat` controls the git URL shown in the
+`/plugin marketplace add` install command: `ssh` (the default,
+`git@host:owner/repo.git`) or `https` (`https://host/owner/repo.git`).
+Without configuration the page shows an error explaining what to set.
+
+### Private repos and self-hosted providers
+
+The backend reads the repo with Backstage's `UrlReader`, which resolves hosts
+and credentials from your standard
+[`integrations`](https://backstage.io/docs/integrations/) configuration — the
+same one the catalog uses. A public repo needs nothing. For a private repo,
+add (or reuse) the credentials for its host:
+
+```yaml
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN}
+  gitlab:
+    - host: gitlab.com
+      token: ${GITLAB_TOKEN}
+  bitbucketCloud:
+    - username: ${BITBUCKET_USERNAME}
+      appPassword: ${BITBUCKET_APP_PASSWORD}
+```
+
+Self-hosted GitHub Enterprise, GitLab, and Bitbucket Server instances work the
+same way — declare the host under `integrations` and use its web URL in
+`skillsMarketplace.url`.

--- a/plugins/skills-marketplace/package.json
+++ b/plugins/skills-marketplace/package.json
@@ -65,7 +65,12 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.36.5"
+    "@backstage/cli": "^0.36.5",
+    "@backstage/core-app-api": "^1.20.4",
+    "@backstage/frontend-test-utils": "^0.6.3",
+    "@backstage/test-utils": "^1.7.21",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1"
   },
   "files": [
     "dist"

--- a/plugins/skills-marketplace/package.json
+++ b/plugins/skills-marketplace/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@globallogicuki/backstage-plugin-skills-marketplace",
+  "description": "Browse and install shared Claude Code skills from a Claude Code marketplace repo.",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/globallogicuki/globallogic-backstage-plugins/tree/main/plugins/skills-marketplace",
+  "bugs": {
+    "url": "https://github.com/globallogicuki/globallogic-backstage-plugins/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:globallogicuki/globallogic-backstage-plugins",
+    "directory": "plugins/skills-marketplace"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin",
+    "pluginId": "skills-marketplace",
+    "pluginPackages": [
+      "@globallogicuki/backstage-plugin-skills-marketplace",
+      "@globallogicuki/backstage-plugin-skills-marketplace-backend"
+    ]
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.tsx",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.tsx"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/core-compat-api": "^0.5.14",
+    "@backstage/core-components": "^0.18.13",
+    "@backstage/core-plugin-api": "^1.12.9",
+    "@backstage/frontend-plugin-api": "^0.18.0",
+    "@material-ui/core": "^4.12.2",
+    "@material-ui/icons": "^4.9.1",
+    "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.36.5"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/skills-marketplace/src/SkillCard.test.tsx
+++ b/plugins/skills-marketplace/src/SkillCard.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { SkillCard } from './SkillCard';
+import { Skill } from './api';
+
+const skill: Skill = {
+  name: 'deck-gl',
+  source: './skills/deck-gl',
+  description: 'Build PowerPoint decks',
+  category: 'presentations',
+  keywords: ['pptx', 'slides', 'deck', 'template', 'brand', 'extra'],
+};
+
+describe('SkillCard', () => {
+  it('renders name, description, category and at most five keywords', async () => {
+    await renderInTestApp(<SkillCard skill={skill} onSelect={jest.fn()} />);
+
+    expect(screen.getByText('deck-gl')).toBeInTheDocument();
+    expect(screen.getByText('Build PowerPoint decks')).toBeInTheDocument();
+    expect(screen.getByText('presentations')).toBeInTheDocument();
+    expect(screen.getByText('pptx')).toBeInTheDocument();
+    expect(screen.getByText('brand')).toBeInTheDocument();
+    expect(screen.queryByText('extra')).toBeNull();
+  });
+
+  it('omits category and keyword chips when absent', async () => {
+    await renderInTestApp(
+      <SkillCard
+        skill={{ name: 'plain', source: './plain', description: 'No tags' }}
+        onSelect={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('plain')).toBeInTheDocument();
+    expect(screen.queryByText('presentations')).toBeNull();
+  });
+
+  it('calls onSelect with the skill when clicked', async () => {
+    const onSelect = jest.fn();
+    await renderInTestApp(<SkillCard skill={skill} onSelect={onSelect} />);
+
+    screen.getByTestId('skill-card-deck-gl').click();
+
+    expect(onSelect).toHaveBeenCalledWith(skill);
+  });
+});

--- a/plugins/skills-marketplace/src/SkillCard.tsx
+++ b/plugins/skills-marketplace/src/SkillCard.tsx
@@ -1,0 +1,57 @@
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardContent from '@material-ui/core/CardContent';
+import Chip from '@material-ui/core/Chip';
+import Typography from '@material-ui/core/Typography';
+import { Skill } from './api';
+import { useSkillsStyles } from './styles';
+
+/**
+ * One skill as a standard themed card. Clicking it opens the detail drawer.
+ */
+export const SkillCard = ({
+  skill,
+  onSelect,
+}: {
+  skill: Skill;
+  onSelect: (skill: Skill) => void;
+}) => {
+  const classes = useSkillsStyles();
+  const keywords = skill.keywords ?? [];
+
+  return (
+    <Card className={classes.card}>
+      <CardActionArea
+        className={classes.cardActionArea}
+        onClick={() => onSelect(skill)}
+        data-testid={`skill-card-${skill.name}`}
+      >
+        <CardContent className={classes.cardContent}>
+          <div className={classes.cardHeader}>
+            <Typography variant="h6" className={classes.cardName}>
+              {skill.name}
+            </Typography>
+            {skill.category && (
+              <Chip label={skill.category} size="small" variant="outlined" />
+            )}
+          </div>
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            component="div"
+            className={classes.cardDescription}
+          >
+            {skill.description}
+          </Typography>
+          {keywords.length > 0 && (
+            <div className={classes.chips}>
+              {keywords.slice(0, 5).map(kw => (
+                <Chip key={kw} label={kw} size="small" />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};

--- a/plugins/skills-marketplace/src/SkillCard.tsx
+++ b/plugins/skills-marketplace/src/SkillCard.tsx
@@ -6,9 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import { Skill } from './api';
 import { useSkillsStyles } from './styles';
 
-/**
- * One skill as a standard themed card. Clicking it opens the detail drawer.
- */
+/** One skill as a card; clicking it opens the detail drawer. */
 export const SkillCard = ({
   skill,
   onSelect,

--- a/plugins/skills-marketplace/src/SkillDetailDrawer.test.tsx
+++ b/plugins/skills-marketplace/src/SkillDetailDrawer.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { SkillDetailDrawer } from './SkillDetailDrawer';
+import { Skill, SkillsMarketplaceApi, skillsMarketplaceApiRef } from './api';
+
+const skill: Skill = {
+  name: 'deck-gl',
+  source: './skills/deck-gl',
+  description: 'Build PowerPoint decks',
+  category: 'presentations',
+  keywords: ['pptx', 'slides'],
+};
+
+describe('SkillDetailDrawer', () => {
+  const getSkillDoc = jest.fn();
+  const mockApi = { getSkillDoc } as unknown as SkillsMarketplaceApi;
+
+  const render = (selected: Skill | null, onClose = jest.fn()) =>
+    renderInTestApp(
+      <TestApiProvider apis={[[skillsMarketplaceApiRef, mockApi]]}>
+        <SkillDetailDrawer
+          skill={selected}
+          marketplaceName="my-marketplace"
+          installUrl="git@github.com:my-org/my-repo.git"
+          onClose={onClose}
+        />
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    getSkillDoc.mockReset();
+  });
+
+  it('renders nothing when no skill is selected', async () => {
+    await render(null);
+
+    expect(screen.queryByText('Install in Claude Code')).toBeNull();
+  });
+
+  it('renders skill details, install commands, and documentation', async () => {
+    getSkillDoc.mockResolvedValue({
+      frontmatter: { name: 'deck-gl' },
+      body: 'Doc body text',
+    });
+
+    await render(skill);
+
+    expect(screen.getByText('deck-gl')).toBeInTheDocument();
+    expect(screen.getByText('Build PowerPoint decks')).toBeInTheDocument();
+    expect(screen.getByText('presentations')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '/plugin marketplace add git@github.com:my-org/my-repo.git',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('/plugin install deck-gl@my-marketplace'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Doc body text')).toBeInTheDocument();
+    });
+    expect(getSkillDoc).toHaveBeenCalledWith('./skills/deck-gl');
+  });
+
+  it('shows an empty state when the skill has no SKILL.md', async () => {
+    getSkillDoc.mockResolvedValue(undefined);
+
+    await render(skill);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/does not provide SKILL.md documentation/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error panel when the documentation fails to load', async () => {
+    getSkillDoc.mockRejectedValue(new Error('boom'));
+
+    await render(skill);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/boom/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    getSkillDoc.mockResolvedValue(undefined);
+    const onClose = jest.fn();
+
+    await render(skill, onClose);
+
+    screen.getByLabelText('Close').click();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
+++ b/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
@@ -1,0 +1,135 @@
+import Chip from '@material-ui/core/Chip';
+import Drawer from '@material-ui/core/Drawer';
+import Divider from '@material-ui/core/Divider';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import CloseIcon from '@material-ui/icons/Close';
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  Progress,
+  MarkdownContent,
+  CopyTextButton,
+  ResponseErrorPanel,
+} from '@backstage/core-components';
+import { Skill, skillsMarketplaceApiRef } from './api';
+import { useSkillsStyles } from './styles';
+
+const InstallCommand = ({ command }: { command: string }) => {
+  const classes = useSkillsStyles();
+  return (
+    <div className={classes.install}>
+      <code className={classes.command}>{command}</code>
+      <CopyTextButton text={command} tooltipText="Copied to clipboard" />
+    </div>
+  );
+};
+
+/**
+ * Skill detail as a right-hand drawer: name, description, category and
+ * keywords up top, copy-able Claude Code install commands, then the skill's
+ * rendered SKILL.md documentation.
+ */
+export const SkillDetailDrawer = ({
+  skill,
+  marketplaceName,
+  installUrl,
+  onClose,
+}: {
+  skill: Skill | null;
+  marketplaceName: string;
+  installUrl: string;
+  onClose: () => void;
+}) => {
+  const classes = useSkillsStyles();
+  const skillsMarketplaceApi = useApi(skillsMarketplaceApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    if (!skill) return undefined;
+    return skillsMarketplaceApi.getSkillDoc(skill.source);
+  }, [skill?.source]);
+
+  const addCommand = `/plugin marketplace add ${installUrl}`;
+  const installCommand = skill
+    ? `/plugin install ${skill.name}@${marketplaceName}`
+    : '';
+
+  return (
+    <Drawer
+      anchor="right"
+      open={Boolean(skill)}
+      onClose={onClose}
+      classes={{ paper: classes.drawerPaper }}
+    >
+      {skill && (
+        <>
+          <div className={classes.drawerHeader}>
+            <div className={classes.drawerTitleBlock}>
+              <Typography variant="h5" className={classes.drawerName}>
+                {skill.name}
+              </Typography>
+              <Typography
+                variant="body1"
+                color="textSecondary"
+                className={classes.drawerDescription}
+              >
+                {skill.description}
+              </Typography>
+              <div className={classes.drawerMeta}>
+                {skill.category && (
+                  <Chip
+                    label={skill.category}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
+                {(skill.keywords ?? []).map(kw => (
+                  <Chip key={kw} label={kw} size="small" />
+                ))}
+              </div>
+            </div>
+            <IconButton onClick={onClose} aria-label="Close" size="small">
+              <CloseIcon />
+            </IconButton>
+          </div>
+
+          <Divider />
+
+          <div className={classes.drawerSection}>
+            <Typography variant="h6" className={classes.sectionTitle}>
+              Install in Claude Code
+            </Typography>
+            <InstallCommand command={addCommand} />
+            <InstallCommand command={installCommand} />
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              component="p"
+              className={classes.installHint}
+            >
+              Run the first command once to register the marketplace, then the
+              second to install this skill. Skip the first if you've already
+              added the <code>{marketplaceName}</code> marketplace.
+            </Typography>
+          </div>
+
+          <Divider />
+
+          <div className={classes.drawerBody}>
+            <Typography variant="h6" className={classes.sectionTitle}>
+              Documentation
+            </Typography>
+            {loading && <Progress />}
+            {error && <ResponseErrorPanel error={error} />}
+            {!loading && !error && !value && (
+              <Typography variant="body2" color="textSecondary">
+                This skill does not provide SKILL.md documentation.
+              </Typography>
+            )}
+            {value && <MarkdownContent content={value.body} dialect="gfm" />}
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+};

--- a/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
+++ b/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
@@ -25,11 +25,7 @@ const InstallCommand = ({ command }: { command: string }) => {
   );
 };
 
-/**
- * Skill detail as a right-hand drawer: name, description, category and
- * keywords up top, copy-able Claude Code install commands, then the skill's
- * rendered SKILL.md documentation.
- */
+/** Skill detail drawer: metadata, install commands, and SKILL.md docs. */
 export const SkillDetailDrawer = ({
   skill,
   marketplaceName,

--- a/plugins/skills-marketplace/src/SkillsMarketplacePage.test.tsx
+++ b/plugins/skills-marketplace/src/SkillsMarketplacePage.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { SkillsMarketplacePage } from './SkillsMarketplacePage';
+import {
+  MarketplaceResponse,
+  SkillsMarketplaceApi,
+  skillsMarketplaceApiRef,
+} from './api';
+
+const response: MarketplaceResponse = {
+  marketplace: {
+    name: 'my-marketplace',
+    plugins: [
+      {
+        name: 'deck-gl',
+        source: './skills/deck-gl',
+        description: 'Build PowerPoint decks',
+        category: 'presentations',
+        keywords: ['pptx'],
+      },
+      {
+        name: 'jira-workflow',
+        source: './skills/jira-workflow',
+        description: 'Work Jira tickets',
+        category: 'workflow',
+        keywords: ['jira'],
+      },
+    ],
+  },
+  installUrl: 'git@github.com:my-org/my-repo.git',
+};
+
+describe('SkillsMarketplacePage', () => {
+  const getMarketplace = jest.fn();
+  const getSkillDoc = jest.fn();
+  const mockApi = {
+    getMarketplace,
+    getSkillDoc,
+  } as unknown as SkillsMarketplaceApi;
+
+  const render = () =>
+    renderInTestApp(
+      <TestApiProvider apis={[[skillsMarketplaceApiRef, mockApi]]}>
+        <SkillsMarketplacePage />
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    getMarketplace.mockReset();
+    getSkillDoc.mockReset();
+    getSkillDoc.mockResolvedValue(undefined);
+  });
+
+  it('shows a progress indicator while loading', async () => {
+    getMarketplace.mockReturnValue(new Promise(() => {}));
+
+    await render();
+
+    // Progress renders after a short built-in delay.
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error panel when the marketplace fails to load', async () => {
+    getMarketplace.mockRejectedValue(new Error('not configured'));
+
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/not configured/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders a card per skill with the result count', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('skill-card-jira-workflow')).toBeInTheDocument();
+    expect(screen.getByText('2 of 2')).toBeInTheDocument();
+  });
+
+  it('filters skills by search query', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Search skills/), {
+      target: { value: 'jira' },
+    });
+
+    expect(screen.queryByTestId('skill-card-deck-gl')).toBeNull();
+    expect(screen.getByTestId('skill-card-jira-workflow')).toBeInTheDocument();
+    expect(screen.getByText('1 of 2')).toBeInTheDocument();
+  });
+
+  it('filters skills by category chip', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    // The filter chips are clickable (role button); the card chips are not.
+    fireEvent.click(screen.getByRole('button', { name: 'presentations' }));
+
+    expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-card-jira-workflow')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    expect(screen.getByTestId('skill-card-jira-workflow')).toBeInTheDocument();
+  });
+
+  it('shows an empty message when nothing matches', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Search skills/), {
+      target: { value: 'nomatch' },
+    });
+
+    expect(
+      screen.getByText('No skills match your search.'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the detail drawer when a card is clicked', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('skill-card-deck-gl'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Install in Claude Code')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('/plugin install deck-gl@my-marketplace'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
+++ b/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
@@ -69,8 +69,7 @@ export const SkillsMarketplacePage = () => {
   const total = marketplace?.plugins.length ?? 0;
 
   return (
-    /* No <Page>/<Header>: in the new frontend system the app shell renders the
-       page title from the `title` on the PageBlueprint in alpha.tsx. */
+    /* No <Page>/<Header>: the app shell renders the PageBlueprint title. */
     <Content>
       {loading && <Progress />}
       {error && <ResponseErrorPanel error={error} />}

--- a/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
+++ b/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from 'react';
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Typography from '@material-ui/core/Typography';
+import SearchIcon from '@material-ui/icons/Search';
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  Content,
+  Progress,
+  ResponseErrorPanel,
+} from '@backstage/core-components';
+import { Skill, skillsMarketplaceApiRef } from './api';
+import { SkillCard } from './SkillCard';
+import { SkillDetailDrawer } from './SkillDetailDrawer';
+import { useSkillsStyles } from './styles';
+
+const ALL = '__all__';
+
+const matches = (skill: Skill, query: string): boolean => {
+  if (!query) return true;
+  const haystack = [
+    skill.name,
+    skill.description,
+    skill.category ?? '',
+    ...(skill.keywords ?? []),
+  ]
+    .join(' ')
+    .toLowerCase();
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every(term => haystack.includes(term));
+};
+
+export const SkillsMarketplacePage = () => {
+  const classes = useSkillsStyles();
+  const skillsMarketplaceApi = useApi(skillsMarketplaceApiRef);
+
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<string>(ALL);
+  const [selected, setSelected] = useState<Skill | null>(null);
+
+  const { value, loading, error } = useAsync(
+    () => skillsMarketplaceApi.getMarketplace(),
+    [skillsMarketplaceApi],
+  );
+
+  const marketplace = value?.marketplace;
+
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    marketplace?.plugins.forEach(p => p.category && set.add(p.category));
+    return Array.from(set).sort();
+  }, [marketplace]);
+
+  const visible = useMemo(() => {
+    const plugins = marketplace?.plugins ?? [];
+    return plugins
+      .filter(p => category === ALL || p.category === category)
+      .filter(p => matches(p, query))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [marketplace, category, query]);
+
+  const total = marketplace?.plugins.length ?? 0;
+
+  return (
+    /* No <Page>/<Header>: in the new frontend system the app shell renders the
+       page title from the `title` on the PageBlueprint in alpha.tsx. */
+    <Content>
+      {loading && <Progress />}
+      {error && <ResponseErrorPanel error={error} />}
+
+      {marketplace && (
+        <>
+          <Box className={classes.filters}>
+            <TextField
+              className={classes.search}
+              variant="outlined"
+              size="small"
+              placeholder="Search skills by name, description, or keyword…"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            {categories.length > 0 && (
+              <div className={classes.categories}>
+                <Chip
+                  label="All"
+                  size="small"
+                  clickable
+                  color={category === ALL ? 'primary' : 'default'}
+                  onClick={() => setCategory(ALL)}
+                />
+                {categories.map(cat => (
+                  <Chip
+                    key={cat}
+                    label={cat}
+                    size="small"
+                    clickable
+                    color={category === cat ? 'primary' : 'default'}
+                    onClick={() => setCategory(cat)}
+                  />
+                ))}
+              </div>
+            )}
+            <Typography
+              component="span"
+              variant="body2"
+              className={classes.resultCount}
+            >
+              {visible.length} of {total}
+            </Typography>
+          </Box>
+
+          {visible.length === 0 ? (
+            <Typography variant="body2" className={classes.empty}>
+              No skills match your search.
+            </Typography>
+          ) : (
+            <Grid container spacing={2}>
+              {visible.map(skill => (
+                <Grid item key={skill.name} xs={12} sm={6} md={4} lg={3}>
+                  <SkillCard skill={skill} onSelect={setSelected} />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+        </>
+      )}
+
+      {value && (
+        <SkillDetailDrawer
+          skill={selected}
+          marketplaceName={value.marketplace.name}
+          installUrl={value.installUrl}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </Content>
+  );
+};

--- a/plugins/skills-marketplace/src/alpha.test.tsx
+++ b/plugins/skills-marketplace/src/alpha.test.tsx
@@ -1,0 +1,50 @@
+import { screen, waitFor } from '@testing-library/react';
+import {
+  createExtensionTester,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import plugin, { skillsMarketplacePage } from './alpha';
+import { SkillsMarketplaceApi, skillsMarketplaceApiRef } from './api';
+
+// New-frontend-system render tests are heavy; give them headroom over the
+// inner waitFor timeout so they don't flake against jest's 5s default.
+jest.setTimeout(30000);
+
+describe('alpha plugin', () => {
+  it('exports the api and page extensions', () => {
+    expect(plugin.pluginId).toBe('skills-marketplace');
+  });
+
+  it('renders the skills marketplace page', async () => {
+    const mockApi = {
+      getMarketplace: jest.fn().mockResolvedValue({
+        marketplace: {
+          name: 'my-marketplace',
+          plugins: [
+            {
+              name: 'deck-gl',
+              source: './skills/deck-gl',
+              description: 'Build PowerPoint decks',
+            },
+          ],
+        },
+        installUrl: 'git@github.com:my-org/my-repo.git',
+      }),
+      getSkillDoc: jest.fn().mockResolvedValue(undefined),
+    } as unknown as SkillsMarketplaceApi;
+
+    renderInTestApp(
+      <TestApiProvider apis={[[skillsMarketplaceApiRef, mockApi]]}>
+        {createExtensionTester(skillsMarketplacePage).reactElement()}
+      </TestApiProvider>,
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+});

--- a/plugins/skills-marketplace/src/alpha.tsx
+++ b/plugins/skills-marketplace/src/alpha.tsx
@@ -1,0 +1,47 @@
+import {
+  ApiBlueprint,
+  PageBlueprint,
+  createFrontendPlugin,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/frontend-plugin-api';
+import { convertLegacyRouteRef } from '@backstage/core-compat-api';
+import StorefrontIcon from '@material-ui/icons/Storefront';
+import { SkillsMarketplaceClient, skillsMarketplaceApiRef } from './api';
+import { rootRouteRef } from './routes';
+
+/**
+ * @alpha
+ */
+const skillsMarketplaceApi = ApiBlueprint.make({
+  params: defineParams =>
+    defineParams({
+      api: skillsMarketplaceApiRef,
+      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new SkillsMarketplaceClient({ discoveryApi, fetchApi }),
+    }),
+});
+
+/**
+ * @alpha
+ */
+const skillsMarketplacePage = PageBlueprint.make({
+  name: 'page',
+  params: {
+    path: '/skills',
+    title: 'Skill Marketplace',
+    icon: <StorefrontIcon />,
+    routeRef: convertLegacyRouteRef(rootRouteRef),
+    loader: () =>
+      import('./SkillsMarketplacePage').then(m => <m.SkillsMarketplacePage />),
+  },
+});
+
+/**
+ * @alpha
+ */
+export default createFrontendPlugin({
+  pluginId: 'skills-marketplace',
+  extensions: [skillsMarketplaceApi, skillsMarketplacePage],
+});

--- a/plugins/skills-marketplace/src/alpha.tsx
+++ b/plugins/skills-marketplace/src/alpha.tsx
@@ -13,7 +13,7 @@ import { rootRouteRef } from './routes';
 /**
  * @alpha
  */
-const skillsMarketplaceApi = ApiBlueprint.make({
+export const skillsMarketplaceApi = ApiBlueprint.make({
   params: defineParams =>
     defineParams({
       api: skillsMarketplaceApiRef,
@@ -26,7 +26,7 @@ const skillsMarketplaceApi = ApiBlueprint.make({
 /**
  * @alpha
  */
-const skillsMarketplacePage = PageBlueprint.make({
+export const skillsMarketplacePage = PageBlueprint.make({
   name: 'page',
   params: {
     path: '/skills',

--- a/plugins/skills-marketplace/src/api.test.ts
+++ b/plugins/skills-marketplace/src/api.test.ts
@@ -1,0 +1,125 @@
+import { SkillsMarketplaceClient, parseFrontmatter } from './api';
+
+const mockClient = (response: Partial<Response>) => {
+  const fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    ...response,
+  });
+  const client = new SkillsMarketplaceClient({
+    discoveryApi: {
+      getBaseUrl: async () => 'http://backend/api/skills-marketplace',
+    },
+    fetchApi: { fetch } as any,
+  });
+  return { client, fetch };
+};
+
+describe('SkillsMarketplaceClient', () => {
+  describe('getMarketplace', () => {
+    it('fetches the marketplace from the backend', async () => {
+      const payload = {
+        marketplace: { name: 'my-marketplace', plugins: [] },
+        installUrl: 'git@github.com:my-org/my-repo.git',
+      };
+      const { client, fetch } = mockClient({ json: async () => payload });
+
+      await expect(client.getMarketplace()).resolves.toEqual(payload);
+      expect(fetch).toHaveBeenCalledWith(
+        'http://backend/api/skills-marketplace/marketplace',
+        expect.anything(),
+      );
+    });
+
+    it('throws the backend error message on failure', async () => {
+      const { client } = mockClient({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: { message: 'not configured' } }),
+      });
+
+      await expect(client.getMarketplace()).rejects.toThrow('not configured');
+    });
+  });
+
+  describe('getSkillDoc', () => {
+    it('fetches and parses a SKILL.md', async () => {
+      const { client, fetch } = mockClient({
+        text: async () => '---\nname: foo\n---\n\n# Foo',
+      });
+
+      await expect(client.getSkillDoc('./skills/foo')).resolves.toEqual({
+        frontmatter: { name: 'foo' },
+        body: '# Foo',
+      });
+      expect(fetch).toHaveBeenCalledWith(
+        'http://backend/api/skills-marketplace/skill-doc?source=.%2Fskills%2Ffoo',
+        expect.anything(),
+      );
+    });
+
+    it('returns undefined when the skill has no SKILL.md', async () => {
+      const { client } = mockClient({ ok: false, status: 404 });
+
+      await expect(client.getSkillDoc('./skills/foo')).resolves.toBeUndefined();
+    });
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('splits frontmatter from the body', () => {
+    const raw = [
+      '---',
+      'name: jira-workflow',
+      'description: Work a Jira ticket',
+      '---',
+      '',
+      '# Heading',
+      'Body text.',
+    ].join('\n');
+
+    const { frontmatter, body } = parseFrontmatter(raw);
+
+    expect(frontmatter).toEqual({
+      name: 'jira-workflow',
+      description: 'Work a Jira ticket',
+    });
+    expect(body).toBe('# Heading\nBody text.');
+  });
+
+  it('keeps colons that appear within a value', () => {
+    const raw = [
+      '---',
+      'description: Use when ("pick up GTM-1234"): covers PRs',
+      'allowed-tools: mcp__foo__bar, Bash(git:*), Bash(curl:*)',
+      '---',
+      'body',
+    ].join('\n');
+
+    const { frontmatter } = parseFrontmatter(raw);
+
+    expect(frontmatter.description).toBe(
+      'Use when ("pick up GTM-1234"): covers PRs',
+    );
+    expect(frontmatter['allowed-tools']).toBe(
+      'mcp__foo__bar, Bash(git:*), Bash(curl:*)',
+    );
+  });
+
+  it('returns the whole document as the body when there is no frontmatter', () => {
+    const raw = '# Just a heading\nNo frontmatter here.';
+    const { frontmatter, body } = parseFrontmatter(raw);
+
+    expect(frontmatter).toEqual({});
+    expect(body).toBe(raw);
+  });
+
+  it('handles CRLF line endings', () => {
+    const raw = '---\r\nname: x\r\n---\r\nbody line';
+    const { frontmatter, body } = parseFrontmatter(raw);
+
+    expect(frontmatter).toEqual({ name: 'x' });
+    expect(body).toBe('body line');
+  });
+});

--- a/plugins/skills-marketplace/src/api.ts
+++ b/plugins/skills-marketplace/src/api.ts
@@ -1,0 +1,122 @@
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+} from '@backstage/frontend-plugin-api';
+
+/** A single skill entry as declared in `.claude-plugin/marketplace.json`. */
+export type Skill = {
+  name: string;
+  /** Path within the repo, e.g. `./skills/deck-gl`. */
+  source: string;
+  description: string;
+  category?: string;
+  keywords?: string[];
+};
+
+/** The parsed `.claude-plugin/marketplace.json` manifest. */
+export type Marketplace = {
+  name: string;
+  owner?: { name?: string; email?: string };
+  description?: string;
+  plugins: Skill[];
+};
+
+/** The marketplace manifest plus repo metadata derived by the backend. */
+export type MarketplaceResponse = {
+  marketplace: Marketplace;
+  /** Git URL of the marketplace repo shown in the install command. */
+  installUrl: string;
+};
+
+/** A skill's `SKILL.md` split into frontmatter fields and the markdown body. */
+export type SkillDoc = {
+  /** Raw key/value pairs from the YAML frontmatter block (values kept as strings). */
+  frontmatter: Record<string, string>;
+  /** Markdown body with the frontmatter block removed. */
+  body: string;
+};
+
+export interface SkillsMarketplaceApi {
+  getMarketplace(): Promise<MarketplaceResponse>;
+  /**
+   * Fetch a skill's SKILL.md. Returns undefined when the skill has no
+   * SKILL.md (not every marketplace entry does).
+   */
+  getSkillDoc(source: string): Promise<SkillDoc | undefined>;
+}
+
+export const skillsMarketplaceApiRef = createApiRef<SkillsMarketplaceApi>({
+  id: 'plugin.skills-marketplace.service',
+});
+
+export class SkillsMarketplaceClient implements SkillsMarketplaceApi {
+  private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
+
+  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
+    this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
+  }
+
+  async getMarketplace(): Promise<MarketplaceResponse> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('skills-marketplace');
+    const response = await this.fetchApi.fetch(`${baseUrl}/marketplace`, {
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error(await this.errorMessage(response));
+    }
+    return (await response.json()) as MarketplaceResponse;
+  }
+
+  async getSkillDoc(source: string): Promise<SkillDoc | undefined> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('skills-marketplace');
+    const response = await this.fetchApi.fetch(
+      `${baseUrl}/skill-doc?source=${encodeURIComponent(source)}`,
+      { credentials: 'include' },
+    );
+    if (response.status === 404) {
+      return undefined;
+    }
+    if (!response.ok) {
+      throw new Error(await this.errorMessage(response));
+    }
+    return parseFrontmatter(await response.text());
+  }
+
+  private async errorMessage(response: Response): Promise<string> {
+    try {
+      const data = await response.json();
+      if (data.error?.message) {
+        return data.error.message;
+      }
+    } catch {
+      // fall through to the generic message
+    }
+    return `Skills Marketplace request failed (${response.status} ${response.statusText}).`;
+  }
+}
+
+/**
+ * Minimal YAML-frontmatter splitter. Handles the flat `key: value` frontmatter
+ * used by SKILL.md files (name / description / allowed-tools). Not a general
+ * YAML parser — nested structures are kept as their raw string.
+ */
+export function parseFrontmatter(raw: string): SkillDoc {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(raw);
+  if (!match) {
+    return { frontmatter: {}, body: raw };
+  }
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = /^([A-Za-z0-9_-]+):\s?(.*)$/.exec(line);
+    if (kv) {
+      frontmatter[kv[1]] = kv[2].trim();
+    }
+  }
+  // Drop the blank separator line(s) that conventionally sit between the
+  // closing `---` and the body, so the rendered doc starts at real content.
+  const body = raw.slice(match[0].length).replace(/^(?:[ \t]*\r?\n)+/, '');
+  return { frontmatter, body };
+}

--- a/plugins/skills-marketplace/src/api.ts
+++ b/plugins/skills-marketplace/src/api.ts
@@ -39,10 +39,7 @@ export type SkillDoc = {
 
 export interface SkillsMarketplaceApi {
   getMarketplace(): Promise<MarketplaceResponse>;
-  /**
-   * Fetch a skill's SKILL.md. Returns undefined when the skill has no
-   * SKILL.md (not every marketplace entry does).
-   */
+  /** Fetch a skill's SKILL.md; undefined when the skill has none. */
   getSkillDoc(source: string): Promise<SkillDoc | undefined>;
 }
 
@@ -99,9 +96,8 @@ export class SkillsMarketplaceClient implements SkillsMarketplaceApi {
 }
 
 /**
- * Minimal YAML-frontmatter splitter. Handles the flat `key: value` frontmatter
- * used by SKILL.md files (name / description / allowed-tools). Not a general
- * YAML parser — nested structures are kept as their raw string.
+ * Split a SKILL.md into flat `key: value` frontmatter and markdown body.
+ * Not a general YAML parser — nested structures are kept as raw strings.
  */
 export function parseFrontmatter(raw: string): SkillDoc {
   const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(raw);
@@ -115,8 +111,6 @@ export function parseFrontmatter(raw: string): SkillDoc {
       frontmatter[kv[1]] = kv[2].trim();
     }
   }
-  // Drop the blank separator line(s) that conventionally sit between the
-  // closing `---` and the body, so the rendered doc starts at real content.
   const body = raw.slice(match[0].length).replace(/^(?:[ \t]*\r?\n)+/, '');
   return { frontmatter, body };
 }

--- a/plugins/skills-marketplace/src/index.ts
+++ b/plugins/skills-marketplace/src/index.ts
@@ -1,0 +1,14 @@
+export { SkillsMarketplacePage } from './SkillsMarketplacePage';
+export { rootRouteRef } from './routes';
+export {
+  skillsMarketplaceApiRef,
+  SkillsMarketplaceClient,
+  parseFrontmatter,
+} from './api';
+export type {
+  Skill,
+  Marketplace,
+  MarketplaceResponse,
+  SkillDoc,
+  SkillsMarketplaceApi,
+} from './api';

--- a/plugins/skills-marketplace/src/routes.ts
+++ b/plugins/skills-marketplace/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'skills-marketplace',
+});

--- a/plugins/skills-marketplace/src/setupTests.ts
+++ b/plugins/skills-marketplace/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/plugins/skills-marketplace/src/styles.ts
+++ b/plugins/skills-marketplace/src/styles.ts
@@ -1,12 +1,8 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-/**
- * Layout-only styles shared by the page, the cards and the drawer. Colors,
- * fonts, radii and elevation all come from the host app's theme so the plugin
- * looks native in any Backstage instance.
- */
+/** Layout-only styles — colors, fonts, and radii come from the host theme. */
 export const useSkillsStyles = makeStyles(theme => ({
-  /* ── Filters row above the card grid ── */
+  /* Filters row */
   filters: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -34,7 +30,7 @@ export const useSkillsStyles = makeStyles(theme => ({
     color: theme.palette.text.secondary,
   },
 
-  /* ── Skill card ── */
+  /* Skill card */
   card: {
     height: '100%',
     display: 'flex',
@@ -70,7 +66,7 @@ export const useSkillsStyles = makeStyles(theme => ({
     gap: theme.spacing(0.5),
   },
 
-  /* ── Detail drawer ── */
+  /* Detail drawer */
   drawerPaper: {
     width: 720,
     maxWidth: '100vw',

--- a/plugins/skills-marketplace/src/styles.ts
+++ b/plugins/skills-marketplace/src/styles.ts
@@ -1,0 +1,127 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+/**
+ * Layout-only styles shared by the page, the cards and the drawer. Colors,
+ * fonts, radii and elevation all come from the host app's theme so the plugin
+ * looks native in any Backstage instance.
+ */
+export const useSkillsStyles = makeStyles(theme => ({
+  /* ── Filters row above the card grid ── */
+  filters: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  search: {
+    flex: '1 1 260px',
+    maxWidth: 480,
+  },
+  categories: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  },
+  resultCount: {
+    marginLeft: 'auto',
+    color: theme.palette.text.secondary,
+  },
+  empty: {
+    padding: theme.spacing(4, 2),
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+
+  /* ── Skill card ── */
+  card: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  cardActionArea: {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+  cardContent: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  },
+  cardHeader: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+  },
+  cardName: {
+    wordBreak: 'break-word',
+  },
+  cardDescription: {
+    flex: 1,
+  },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+  },
+
+  /* ── Detail drawer ── */
+  drawerPaper: {
+    width: 720,
+    maxWidth: '100vw',
+  },
+  drawerHeader: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    padding: theme.spacing(3, 3, 2, 3),
+  },
+  drawerTitleBlock: {
+    minWidth: 0,
+  },
+  drawerName: {
+    wordBreak: 'break-word',
+  },
+  drawerDescription: {
+    marginTop: theme.spacing(0.5),
+  },
+  drawerMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(1.5),
+  },
+  drawerSection: {
+    padding: theme.spacing(2, 3),
+  },
+  sectionTitle: {
+    marginBottom: theme.spacing(1),
+  },
+  install: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    backgroundColor: theme.palette.background.default,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    padding: theme.spacing(1, 1, 1, 2),
+    marginBottom: theme.spacing(1),
+  },
+  command: {
+    overflowX: 'auto',
+    whiteSpace: 'pre',
+  },
+  installHint: {
+    marginTop: theme.spacing(1),
+  },
+  drawerBody: {
+    padding: theme.spacing(1, 3, 4, 3),
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6112,12 +6112,17 @@ __metadata:
   resolution: "@globallogicuki/backstage-plugin-skills-marketplace@workspace:plugins/skills-marketplace"
   dependencies:
     "@backstage/cli": "npm:^0.36.5"
+    "@backstage/core-app-api": "npm:^1.20.4"
     "@backstage/core-compat-api": "npm:^0.5.14"
     "@backstage/core-components": "npm:^0.18.13"
     "@backstage/core-plugin-api": "npm:^1.12.9"
     "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/frontend-test-utils": "npm:^0.6.3"
+    "@backstage/test-utils": "npm:^1.7.21"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
+    "@testing-library/jest-dom": "npm:^6.4.2"
+    "@testing-library/react": "npm:^14.2.1"
     react-use: "npm:^17.2.4"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6090,6 +6090,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@globallogicuki/backstage-plugin-skills-marketplace-backend@workspace:^, @globallogicuki/backstage-plugin-skills-marketplace-backend@workspace:plugins/skills-marketplace-backend":
+  version: 0.0.0-use.local
+  resolution: "@globallogicuki/backstage-plugin-skills-marketplace-backend@workspace:plugins/skills-marketplace-backend"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.10.0"
+    "@backstage/backend-test-utils": "npm:^1.11.6"
+    "@backstage/cli": "npm:^0.36.5"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/integration": "npm:^2.1.0"
+    "@types/express": "npm:^4.17.6"
+    "@types/supertest": "npm:^6.0.2"
+    express: "npm:^4.17.1"
+    express-promise-router: "npm:^4.1.0"
+    supertest: "npm:^6.3.4"
+  languageName: unknown
+  linkType: soft
+
+"@globallogicuki/backstage-plugin-skills-marketplace@workspace:^, @globallogicuki/backstage-plugin-skills-marketplace@workspace:plugins/skills-marketplace":
+  version: 0.0.0-use.local
+  resolution: "@globallogicuki/backstage-plugin-skills-marketplace@workspace:plugins/skills-marketplace"
+  dependencies:
+    "@backstage/cli": "npm:^0.36.5"
+    "@backstage/core-compat-api": "npm:^0.5.14"
+    "@backstage/core-components": "npm:^0.18.13"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
 "@globallogicuki/backstage-plugin-terraform-backend@npm:^0.10.6, @globallogicuki/backstage-plugin-terraform-backend@workspace:plugins/terraform-backend":
   version: 0.0.0-use.local
   resolution: "@globallogicuki/backstage-plugin-terraform-backend@workspace:plugins/terraform-backend"
@@ -15377,6 +15411,7 @@ __metadata:
     "@backstage/plugin-techdocs-module-addons-contrib": "npm:^1.1.39"
     "@backstage/plugin-user-settings": "npm:^0.9.6"
     "@backstage/ui": "npm:^0.17.1"
+    "@globallogicuki/backstage-plugin-skills-marketplace": "workspace:^"
     "@globallogicuki/backstage-plugin-terraform": "npm:^0.11.7"
     "@globallogicuki/backstage-plugin-unleash": "workspace:^"
     "@material-ui/core": "npm:^4.12.2"
@@ -15999,6 +16034,7 @@ __metadata:
     "@backstage/plugin-signals-backend": "npm:^0.3.18"
     "@backstage/plugin-techdocs-backend": "npm:^2.2.3"
     "@backstage/plugin-user-settings-backend": "npm:^0.4.6"
+    "@globallogicuki/backstage-plugin-skills-marketplace-backend": "workspace:^"
     "@globallogicuki/backstage-plugin-terraform-backend": "npm:^0.10.6"
     "@globallogicuki/backstage-plugin-unleash-backend": "workspace:^"
     app: "link:../app"


### PR DESCRIPTION
## What

Adds a new plugin pair — `@globallogicuki/backstage-plugin-skills-marketplace` (frontend) and `@globallogicuki/backstage-plugin-skills-marketplace-backend` — that surfaces shared **Claude Code skills** from a Claude Code marketplace repo (a repo containing `.claude-plugin/marketplace.json`) as a browsable, searchable marketplace inside Backstage.

- Skill cards with name, description, category, and keyword chips; full-text search and one-click category filtering (categories are derived from the manifest).
- A detail drawer with the skill's rendered `SKILL.md` documentation and copy-able Claude Code install commands (`/plugin marketplace add …` + `/plugin install …`).
- Styled entirely with the host app's default theme (standard MUI cards/chips/drawer) — no bespoke design-system dependency.

## How it reads the repo

Following the pattern of the community ADR plugin, the backend reads the repo through Backstage's `UrlReader` and the standard `integrations` config:

- **One config value**: `skillsMarketplace.url` — the web URL of the repo tree at a branch (e.g. `https://github.com/my-org/skills-marketplace/tree/main`). No provider enum, no proxy entries.
- **GitHub, GitLab, and Bitbucket** (cloud and self-hosted) all work, **including private repos** — credentials come from the instance's existing `integrations.*` config. Verified end-to-end against a private Bitbucket Cloud repo.
- Optional `skillsMarketplace.installUrlFormat: ssh | https` controls the git URL shown in the install command (default `ssh`).
- 5-minute response caching to protect API rate limits; the `skill-doc` endpoint validates the source path so it can't be used as an arbitrary file reader.

## Wiring

- New-frontend-system alpha entry points (`ApiBlueprint` + `PageBlueprint` with nav title/icon); classic-system exports documented in the README.
- Wired into the example app (`/skills` page) and backend, with a commented config template in `app-config.local.tpl.yaml` including the private-repo `integrations` credentials.
- Changeset included (minor, initial release of both packages).

## Testing

- 24 unit tests across both packages (router endpoints, install-URL derivation per provider, config validation, API client, frontmatter parsing).
- Verified live in the dev app against: the public Anthropic `anthropics/skills` GitHub marketplace, and the (now private) `ecs-group/skills-marketplace` Bitbucket repo with scoped API-token credentials, in both `ssh` and `https` install-URL formats.