### PR TITLE
feat: add tech-insights-overview plugin

### DIFF
--- a/.changeset/add-tech-insights-overview.md
+++ b/.changeset/add-tech-insights-overview.md
@@ -1,0 +1,5 @@
+---
+'@globallogicuki/backstage-plugin-tech-insights-overview': minor
+---
+
+Initial release of the Tech Insights Overview plugin: a catalog-wide dashboard that aggregates check results across every component in the catalog — a summary band, per-check tiles that double as filters, a worst-first failures table, and failing-by-owner bars. Works against any tech-insights backend with configured checks; discovers checks dynamically and needs no configuration of its own.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -143,6 +143,56 @@ integrations:
     #   apiBaseUrl: https://ghe.example.net/api/v3
     #   token: ${GHE_TOKEN}
 
+# Demo tech-insights setup feeding the estate-health page: the built-in
+# metadata/ownership fact retrievers plus a few json-rules-engine checks.
+techInsights:
+  factRetrievers:
+    # Per-minute cadence so the demo app has facts right after startup.
+    entityMetadataFactRetriever:
+      cadence: '* * * * *'
+      lifecycle: { timeToLive: { weeks: 2 } }
+    entityOwnershipFactRetriever:
+      cadence: '* * * * *'
+      lifecycle: { timeToLive: { weeks: 2 } }
+  factChecker:
+    checks:
+      hasOwner:
+        type: json-rules-engine
+        name: Has owner
+        description: The entity declares a spec.owner
+        factIds:
+          - entityOwnershipFactRetriever
+        rule:
+          conditions:
+            all:
+              - fact: hasOwner
+                operator: equal
+                value: true
+      hasDescription:
+        type: json-rules-engine
+        name: Has description
+        description: The entity has a metadata.description
+        factIds:
+          - entityMetadataFactRetriever
+        rule:
+          conditions:
+            all:
+              - fact: hasDescription
+                operator: equal
+                value: true
+      hasTags:
+        type: json-rules-engine
+        name: Has tags
+        description: The entity declares metadata.tags
+        factIds:
+          - entityMetadataFactRetriever
+        rule:
+          conditions:
+            all:
+              - fact: hasTags
+                operator: equal
+                value: true
+
 proxy:
   {}
   ### Example for how to add a proxy endpoint for the frontend.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
     "lint": "backstage-cli package lint"
   },
   "dependencies": {
+    "@backstage-community/plugin-tech-insights": "^1.4.0",
     "@backstage/cli": "^0.36.5",
     "@backstage/core-components": "^0.18.13",
     "@backstage/core-plugin-api": "^1.12.9",
@@ -41,6 +42,7 @@
     "@backstage/plugin-user-settings": "^0.9.6",
     "@backstage/ui": "^0.17.1",
     "@globallogicuki/backstage-plugin-skills-marketplace": "workspace:^",
+    "@globallogicuki/backstage-plugin-tech-insights-overview": "workspace:^",
     "@globallogicuki/backstage-plugin-terraform": "^0.11.7",
     "@globallogicuki/backstage-plugin-unleash": "workspace:^",
     "@material-ui/core": "^4.12.2",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,8 @@
 import { createApp } from '@backstage/frontend-defaults';
+// Provides the tech-insights API used by the tech-insights-overview page.
+import techInsightsPlugin from '@backstage-community/plugin-tech-insights/alpha';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import techInsightsOverviewPlugin from '@globallogicuki/backstage-plugin-tech-insights-overview/alpha';
 import skillsMarketplacePlugin from '@globallogicuki/backstage-plugin-skills-marketplace/alpha';
 import terraformPlugin from '@globallogicuki/backstage-plugin-terraform/alpha';
 import unleashPlugin from '@globallogicuki/backstage-plugin-unleash/alpha';
@@ -9,7 +12,9 @@ import { homeModule } from './modules/home';
 export default createApp({
   features: [
     catalogPlugin,
+    techInsightsOverviewPlugin,
     skillsMarketplacePlugin,
+    techInsightsPlugin,
     terraformPlugin,
     unleashPlugin,
     navModule,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,6 +16,8 @@
     "build-image": "docker build ../.. -f Dockerfile --tag backstage"
   },
   "dependencies": {
+    "@backstage-community/plugin-tech-insights-backend": "^3.0.1",
+    "@backstage-community/plugin-tech-insights-backend-module-jsonfc": "^0.9.0",
     "@backstage/backend-defaults": "^0.17.7",
     "@backstage/backend-plugin-api": "^1.10.0",
     "@backstage/config": "^1.3.8",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -69,6 +69,12 @@ backend.add(
   import('@globallogicuki/backstage-plugin-skills-marketplace-backend'),
 );
 
+// tech insights plugin (feeds the estate-health page)
+backend.add(import('@backstage-community/plugin-tech-insights-backend'));
+backend.add(
+  import('@backstage-community/plugin-tech-insights-backend-module-jsonfc'),
+);
+
 // notifications and signals plugins
 backend.add(import('@backstage/plugin-notifications-backend'));
 backend.add(import('@backstage/plugin-signals-backend'));

--- a/plugins/tech-insights-overview/.eslintrc.js
+++ b/plugins/tech-insights-overview/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/tech-insights-overview/README.md
+++ b/plugins/tech-insights-overview/README.md
@@ -1,0 +1,75 @@
+# Tech Insights Overview
+
+A catalog-wide overview for
+[Tech Insights](https://github.com/backstage/community-plugins/tree/main/workspaces/tech-insights):
+one page that aggregates check results across every component in the catalog.
+
+- A summary band: how many components pass everything, and how many have no
+  results yet.
+- One tile per check, worst first, doubling as the page's primary filter.
+- A worst-first table of components with failures, filterable by name, owner,
+  and check.
+- Failing-by-owner bars — the accountability axis the per-check view lacks.
+
+Checks are discovered dynamically from the bulk check response, so the page
+works against whatever checks your tech-insights backend has configured — no
+check IDs are hardcoded and the plugin itself needs no configuration. Styling
+comes entirely from the host app's theme.
+
+## Prerequisites
+
+A working Tech Insights setup:
+
+- `@backstage-community/plugin-tech-insights-backend` (plus a fact checker,
+  e.g. `-backend-module-jsonfc`) with fact retrievers and checks configured
+  under `techInsights` in `app-config.yaml`.
+- The `techInsightsApiRef` registered in the frontend — including
+  `@backstage-community/plugin-tech-insights` in the app provides it.
+
+## Installation
+
+```sh
+yarn --cwd packages/app add @globallogicuki/backstage-plugin-tech-insights-overview
+```
+
+### New frontend system
+
+```tsx
+// packages/app/src/App.tsx
+import techInsightsPlugin from '@backstage-community/plugin-tech-insights/alpha';
+import techInsightsOverviewPlugin from '@globallogicuki/backstage-plugin-tech-insights-overview/alpha';
+
+export default createApp({
+  features: [techInsightsOverviewPlugin, techInsightsPlugin],
+});
+```
+
+This registers an `/tech-insights-overview` page with a sidebar nav item.
+
+### Classic frontend system
+
+```tsx
+import { TechInsightsOverviewPage } from '@globallogicuki/backstage-plugin-tech-insights-overview';
+
+// inside <FlatRoutes>
+<Route path="/tech-insights-overview" element={<TechInsightsOverviewPage />} />;
+
+// packages/app/src/components/Root/Root.tsx
+<SidebarItem
+  icon={EqualizerIcon}
+  to="tech-insights-overview"
+  text="Tech Insights Overview"
+/>;
+```
+
+## How it scores
+
+- **Components only** — logical groupings like Systems have no source
+  location, image, or docs of their own to satisfy a check, and scoring them
+  double-counts the components they contain.
+- A component's denominator is the checks that returned a result for it, so
+  denominators legitimately differ across the catalog.
+- Components with **no results yet** are reported separately, never counted
+  as passing.
+- Owners are keyed by canonical ref (`group:default/platform`), so a group
+  and a user sharing a display name are never merged.

--- a/plugins/tech-insights-overview/package.json
+++ b/plugins/tech-insights-overview/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@globallogicuki/backstage-plugin-tech-insights-overview",
+  "description": "Catalog-wide tech insights overview: aggregates check results across every component, by check and by owner.",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/globallogicuki/globallogic-backstage-plugins/tree/main/plugins/tech-insights-overview",
+  "bugs": {
+    "url": "https://github.com/globallogicuki/globallogic-backstage-plugins/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:globallogicuki/globallogic-backstage-plugins",
+    "directory": "plugins/tech-insights-overview"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin",
+    "pluginId": "tech-insights-overview",
+    "pluginPackages": [
+      "@globallogicuki/backstage-plugin-tech-insights-overview"
+    ]
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.tsx",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.tsx"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage-community/plugin-tech-insights-common": "^0.10.0",
+    "@backstage-community/plugin-tech-insights-react": "^1.6.0",
+    "@backstage/catalog-model": "^1.10.0",
+    "@backstage/core-compat-api": "^0.5.14",
+    "@backstage/core-components": "^0.18.13",
+    "@backstage/core-plugin-api": "^1.12.9",
+    "@backstage/frontend-plugin-api": "^0.18.0",
+    "@backstage/plugin-catalog-react": "^3.2.1",
+    "@material-ui/core": "^4.12.2",
+    "@material-ui/icons": "^4.9.1",
+    "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.36.5",
+    "@backstage/core-app-api": "^1.20.4",
+    "@backstage/frontend-test-utils": "^0.6.3",
+    "@backstage/test-utils": "^1.7.21",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/tech-insights-overview/src/TechInsightsOverviewPage.test.tsx
+++ b/plugins/tech-insights-overview/src/TechInsightsOverviewPage.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { techInsightsApiRef } from '@backstage-community/plugin-tech-insights-react';
+import { TechInsightsOverviewPage } from './TechInsightsOverviewPage';
+
+const entities = [
+  {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'api', namespace: 'default' },
+    spec: { owner: 'team-a' },
+  },
+  {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'web', namespace: 'default' },
+    spec: { owner: 'team-b' },
+  },
+];
+
+const check = (id: string, name: string, failed: boolean) => ({
+  check: { id, name },
+  result: !failed,
+});
+
+const bulk = [
+  {
+    entity: 'component:default/api',
+    results: [
+      check('hasOwner', 'Has owner', true),
+      check('hasDocs', 'Has docs', false),
+    ],
+  },
+  {
+    entity: 'component:default/web',
+    results: [
+      check('hasOwner', 'Has owner', false),
+      check('hasDocs', 'Has docs', false),
+    ],
+  },
+];
+
+describe('TechInsightsOverviewPage', () => {
+  const getEntities = jest.fn();
+  const runBulkChecks = jest.fn();
+  const catalogApi = { getEntities } as any;
+  const techInsightsApi = {
+    runBulkChecks,
+    isCheckResultFailed: (r: any) => r.result === false,
+  } as any;
+
+  const render = () =>
+    renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, catalogApi],
+          [techInsightsApiRef, techInsightsApi],
+        ]}
+      >
+        <TechInsightsOverviewPage />
+      </TestApiProvider>,
+    );
+
+  beforeEach(() => {
+    getEntities.mockReset();
+    runBulkChecks.mockReset();
+    getEntities.mockResolvedValue({ items: entities });
+    runBulkChecks.mockResolvedValue(bulk);
+  });
+
+  it('renders the summary, check tiles, and failures table', async () => {
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getByText('Fully passing')).toBeInTheDocument();
+    });
+    // web fully passes both checks; api fails hasOwner.
+    expect(screen.getByText('of 2 components')).toBeInTheDocument();
+    expect(screen.getByText('Weakest standards')).toBeInTheDocument();
+    // The check appears as both a tile and a failing-check chip on the row.
+    expect(screen.getAllByText('Has owner').length).toBeGreaterThan(0);
+    expect(screen.getByText('api')).toBeInTheDocument();
+    expect(screen.getByText('Failing by owner')).toBeInTheDocument();
+    // The owner appears in both the table row and the owner bars.
+    expect(screen.getAllByText('team-a').length).toBeGreaterThan(0);
+  });
+
+  it('filters the table by name', async () => {
+    // Make both components fail so the table has two rows.
+    runBulkChecks.mockResolvedValue([
+      {
+        entity: 'component:default/api',
+        results: [check('hasOwner', 'Has owner', true)],
+      },
+      {
+        entity: 'component:default/web',
+        results: [check('hasOwner', 'Has owner', true)],
+      },
+    ]);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByText('api')).toBeInTheDocument();
+    });
+    expect(screen.getByText('web')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'api' },
+    });
+
+    expect(screen.getByText('api')).toBeInTheDocument();
+    expect(screen.queryByText('web')).toBeNull();
+    expect(screen.getByText('1 of 2')).toBeInTheDocument();
+  });
+
+  it('scopes the table to a check when its tile is clicked', async () => {
+    await render();
+    await waitFor(() => {
+      expect(screen.getByText('api')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Has owner/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/scoped to has owner/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an empty state when no checks have run', async () => {
+    runBulkChecks.mockResolvedValue([
+      { entity: 'component:default/api', results: [] },
+      { entity: 'component:default/web', results: [] },
+    ]);
+
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getByText('No checks have run yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error panel when loading fails', async () => {
+    getEntities.mockRejectedValue(new Error('catalog down'));
+
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/catalog down/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/plugins/tech-insights-overview/src/TechInsightsOverviewPage.tsx
+++ b/plugins/tech-insights-overview/src/TechInsightsOverviewPage.tsx
@@ -1,0 +1,242 @@
+import { useMemo, useState } from 'react';
+import Box from '@material-ui/core/Box';
+import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
+import MenuItem from '@material-ui/core/MenuItem';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import {
+  Content,
+  Progress,
+  ResponseErrorPanel,
+} from '@backstage/core-components';
+import {
+  useTechInsightsOverview,
+  type OwnerSummary,
+} from './useTechInsightsOverview';
+import { useOverviewStyles } from './styles';
+import { SummaryBand } from './components/SummaryBand';
+import { CheckTiles } from './components/CheckTiles';
+import { FailuresTable } from './components/FailuresTable';
+import { OwnerBars } from './components/OwnerBars';
+import { OwnerGlyph } from './components/OwnerGlyph';
+
+/* The owner filter compares against canonical refs (`group:default/platform`), which
+   always contain a colon — so this bare sentinel cannot collide with a real owner. */
+const ALL = 'all';
+
+export const TechInsightsOverviewPage = () => {
+  const classes = useOverviewStyles();
+  const { loading, error, aggregate } = useTechInsightsOverview();
+
+  const [selectedCheck, setSelectedCheck] = useState<string | null>(null);
+  const [ownerRef, setOwnerRef] = useState<string>(ALL);
+  const [query, setQuery] = useState('');
+
+  const visible = useMemo(() => {
+    if (!aggregate) return [];
+    const q = query.trim().toLowerCase();
+    return aggregate.entities.filter(entity => {
+      if (q && !entity.name.toLowerCase().includes(q)) return false;
+      if (ownerRef !== ALL && entity.ownerRef !== ownerRef) return false;
+      if (selectedCheck && !entity.failedCheckIds.includes(selectedCheck)) {
+        return false;
+      }
+      return true;
+    });
+  }, [aggregate, query, ownerRef, selectedCheck]);
+
+  /* Bars follow the check filter but not the owner filter — an owner comparison that
+     hid every other owner would answer a question nobody asked. The selected owner is
+     highlighted instead. Scoped to a check, a bar counts failing components (each
+     component can fail the selected check once), so the unit is passed along and the
+     failing-checks budget does not apply. */
+  const ownerBars = useMemo<OwnerSummary[]>(() => {
+    if (!aggregate) return [];
+    if (!selectedCheck) return aggregate.owners;
+    const tally = new Map<string, OwnerSummary>();
+    for (const entity of aggregate.entities) {
+      if (!entity.failedCheckIds.includes(selectedCheck)) continue;
+      const current = tally.get(entity.ownerRef) ?? {
+        ownerRef: entity.ownerRef,
+        owner: entity.owner,
+        ownerKind: entity.ownerKind,
+        failing: 0,
+        components: 0,
+      };
+      current.failing += 1;
+      current.components += 1;
+      tally.set(entity.ownerRef, current);
+    }
+    return [...tally.values()].sort(
+      (a, b) => b.failing - a.failing || a.owner.localeCompare(b.owner),
+    );
+  }, [aggregate, selectedCheck]);
+
+  const selectedCheckName = aggregate?.checks.find(
+    c => c.id === selectedCheck,
+  )?.name;
+
+  /* The caption under the owner bars must describe the bars it sits under: scoped to a
+     check, that is the components failing it, not every failing component. */
+  const ownerBarsComponentCount = selectedCheck
+    ? ownerBars.reduce((sum, o) => sum + o.components, 0)
+    : aggregate?.entities.length ?? 0;
+
+  return (
+    /* No <Page>/<Header>: the app shell renders the PageBlueprint title. */
+    <Content>
+      {loading && <Progress />}
+      {error && <ResponseErrorPanel error={error} />}
+
+      {aggregate && aggregate.scored === 0 && (
+        <Typography variant="body2" className={classes.subtle}>
+          No checks have run yet.
+        </Typography>
+      )}
+
+      {aggregate && aggregate.scored > 0 && (
+        <>
+          <Box className={classes.topRow}>
+            <SummaryBand
+              fullyPassing={aggregate.fullyPassing}
+              scored={aggregate.scored}
+              unscored={aggregate.unscored}
+            />
+            <Divider orientation="vertical" flexItem />
+            <Box className={classes.topRowTiles}>
+              {aggregate.checks.length === 0 ? (
+                <>
+                  <Typography variant="h6" gutterBottom>
+                    Weakest standards
+                  </Typography>
+                  <Typography variant="body2" className={classes.subtle}>
+                    No checks are configured.
+                  </Typography>
+                </>
+              ) : (
+                <CheckTiles
+                  title="Weakest standards"
+                  checks={aggregate.checks}
+                  selectedId={selectedCheck}
+                  onSelect={setSelectedCheck}
+                />
+              )}
+            </Box>
+          </Box>
+
+          <Grid container spacing={3} className={classes.sectionGap}>
+            <Grid item xs={12} lg={8}>
+              <Box className={classes.panel}>
+                <Box className={classes.panelHead}>
+                  <Box>
+                    <Typography variant="subtitle1">
+                      <strong>Components with failures</strong>
+                    </Typography>
+                    <Typography variant="caption" className={classes.subtle}>
+                      How many of each component's checks are failing
+                    </Typography>
+                  </Box>
+                  {selectedCheckName && (
+                    <Typography variant="caption" className={classes.subtle}>
+                      scoped to {selectedCheckName.toLowerCase()}
+                    </Typography>
+                  )}
+                </Box>
+
+                <Box className={classes.filters}>
+                  <TextField
+                    className={classes.filter}
+                    label="Name contains"
+                    variant="outlined"
+                    size="small"
+                    value={query}
+                    onChange={e => setQuery(e.target.value)}
+                  />
+                  <TextField
+                    className={classes.filter}
+                    select
+                    label="Owner"
+                    variant="outlined"
+                    size="small"
+                    value={ownerRef}
+                    onChange={e => setOwnerRef(e.target.value)}
+                  >
+                    <MenuItem value={ALL}>Any owner</MenuItem>
+                    {aggregate.owners.map(o => (
+                      <MenuItem key={o.ownerRef} value={o.ownerRef}>
+                        <Box className={classes.ownerCell}>
+                          <OwnerGlyph kind={o.ownerKind} />
+                          {o.owner}
+                        </Box>
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                  <TextField
+                    className={classes.filter}
+                    select
+                    label="Failing check"
+                    variant="outlined"
+                    size="small"
+                    value={selectedCheck ?? ALL}
+                    onChange={e =>
+                      setSelectedCheck(
+                        e.target.value === ALL ? null : e.target.value,
+                      )
+                    }
+                  >
+                    <MenuItem value={ALL}>Any check</MenuItem>
+                    {/* Only checks that actually fail somewhere — offering a filter
+                          that can only return nothing is a dead end. The one exception
+                          is the currently selected check: a fully-passing tile can be
+                          clicked, and the Select must be able to show that value
+                          rather than render blank. */}
+                    {aggregate.checks
+                      .filter(c => c.failing > 0 || c.id === selectedCheck)
+                      .map(c => (
+                        <MenuItem key={c.id} value={c.id}>
+                          {c.name}
+                        </MenuItem>
+                      ))}
+                  </TextField>
+                  <Typography component="span" className={classes.resultCount}>
+                    {visible.length} of {aggregate.entities.length}
+                  </Typography>
+                </Box>
+
+                <FailuresTable
+                  entities={visible}
+                  selectedCheckId={selectedCheck}
+                />
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} lg={4}>
+              <Box className={classes.panel}>
+                <Box className={classes.panelHead}>
+                  <Box>
+                    <Typography variant="subtitle1">
+                      <strong>Failing by owner</strong>
+                    </Typography>
+                    <Typography variant="caption" className={classes.subtle}>
+                      From spec.owner, across {ownerBarsComponentCount}{' '}
+                      component{ownerBarsComponentCount === 1 ? '' : 's'}
+                      {selectedCheckName
+                        ? ` failing ${selectedCheckName.toLowerCase()}`
+                        : ''}
+                    </Typography>
+                  </Box>
+                </Box>
+                <OwnerBars
+                  owners={ownerBars}
+                  highlight={ownerRef === ALL ? null : ownerRef}
+                  unit={selectedCheck ? 'components' : 'checks'}
+                />
+              </Box>
+            </Grid>
+          </Grid>
+        </>
+      )}
+    </Content>
+  );
+};

--- a/plugins/tech-insights-overview/src/alpha.test.tsx
+++ b/plugins/tech-insights-overview/src/alpha.test.tsx
@@ -1,0 +1,63 @@
+import { screen, waitFor } from '@testing-library/react';
+import {
+  createExtensionTester,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { techInsightsApiRef } from '@backstage-community/plugin-tech-insights-react';
+import plugin, { techInsightsOverviewPage } from './alpha';
+
+// New-frontend-system render tests are heavy; give them headroom over the
+// inner waitFor timeout so they don't flake against jest's 5s default.
+jest.setTimeout(30000);
+
+describe('alpha plugin', () => {
+  it('exports the page extension', () => {
+    expect(plugin.pluginId).toBe('tech-insights-overview');
+  });
+
+  it('renders the overview page', async () => {
+    const catalogApi = {
+      getEntities: jest.fn().mockResolvedValue({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: { name: 'api', namespace: 'default' },
+            spec: { owner: 'team-a' },
+          },
+        ],
+      }),
+    } as any;
+    const techInsightsApi = {
+      runBulkChecks: jest.fn().mockResolvedValue([
+        {
+          entity: 'component:default/api',
+          results: [
+            { check: { id: 'hasOwner', name: 'Has owner' }, result: false },
+          ],
+        },
+      ]),
+      isCheckResultFailed: (r: any) => r.result === false,
+    } as any;
+
+    renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, catalogApi],
+          [techInsightsApiRef, techInsightsApi],
+        ]}
+      >
+        {createExtensionTester(techInsightsOverviewPage).reactElement()}
+      </TestApiProvider>,
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Fully passing')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  });
+});

--- a/plugins/tech-insights-overview/src/alpha.tsx
+++ b/plugins/tech-insights-overview/src/alpha.tsx
@@ -1,0 +1,32 @@
+import {
+  PageBlueprint,
+  createFrontendPlugin,
+} from '@backstage/frontend-plugin-api';
+import { convertLegacyRouteRef } from '@backstage/core-compat-api';
+import EqualizerIcon from '@material-ui/icons/Equalizer';
+import { rootRouteRef } from './routes';
+
+/**
+ * @alpha
+ */
+export const techInsightsOverviewPage = PageBlueprint.make({
+  name: 'page',
+  params: {
+    path: '/tech-insights-overview',
+    title: 'Tech Insights Overview',
+    icon: <EqualizerIcon />,
+    routeRef: convertLegacyRouteRef(rootRouteRef),
+    loader: () =>
+      import('./TechInsightsOverviewPage').then(m => (
+        <m.TechInsightsOverviewPage />
+      )),
+  },
+});
+
+/**
+ * @alpha
+ */
+export default createFrontendPlugin({
+  pluginId: 'tech-insights-overview',
+  extensions: [techInsightsOverviewPage],
+});

--- a/plugins/tech-insights-overview/src/components/CheckTiles.tsx
+++ b/plugins/tech-insights-overview/src/components/CheckTiles.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Box from '@material-ui/core/Box';
+import ButtonBase from '@material-ui/core/ButtonBase';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import type { CheckSummary } from '../useTechInsightsOverview';
+import { checkSeverity, useOverviewStyles } from '../styles';
+
+/**
+ * One tile per check in a single scrollable row, doubling as the page's primary
+ * filter. The arrows in the header page the row; trackpads and touch scroll it
+ * directly, so the scrollbar itself is hidden. A tile is neutral unless the
+ * check is actually being missed, so a healthy catalog is a page with no color.
+ */
+export const CheckTiles = ({
+  title,
+  checks,
+  selectedId,
+  onSelect,
+}: {
+  title: string;
+  checks: CheckSummary[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+}) => {
+  const classes = useOverviewStyles();
+  const scroller = useRef<HTMLDivElement | null>(null);
+  const [canScroll, setCanScroll] = useState({ back: false, forward: false });
+
+  const updateArrows = useCallback(() => {
+    const el = scroller.current;
+    if (!el) return;
+    setCanScroll({
+      back: el.scrollLeft > 0,
+      forward: el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    updateArrows();
+    window.addEventListener('resize', updateArrows);
+    return () => window.removeEventListener('resize', updateArrows);
+  }, [checks, updateArrows]);
+
+  const page = (direction: 1 | -1) => {
+    const el = scroller.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * el.clientWidth * 0.8, behavior: 'smooth' });
+  };
+
+  return (
+    <Box>
+      <Box className={classes.tilesHeader}>
+        <Typography variant="h6">{title}</Typography>
+        <Box className={classes.tilesArrows}>
+          <IconButton
+            size="small"
+            aria-label="Scroll checks back"
+            disabled={!canScroll.back}
+            onClick={() => page(-1)}
+          >
+            <ChevronLeftIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            aria-label="Scroll checks forward"
+            disabled={!canScroll.forward}
+            onClick={() => page(1)}
+          >
+            <ChevronRightIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </Box>
+
+      {/* A plain div rather than Box: the scroller needs a real DOM ref, and
+          MUI v4's Box does not reliably forward one. */}
+      <div
+        className={classes.tilesScroller}
+        ref={scroller}
+        onScroll={updateArrows}
+        role="group"
+        aria-label="Scorecard checks"
+      >
+        {checks.map(check => {
+          const severity = checkSeverity(check.failing, check.total);
+          const passing = check.total - check.failing;
+          const pct = check.total
+            ? Math.round((passing / check.total) * 100)
+            : 100;
+          const selected = selectedId === check.id;
+          const fillClass = {
+            critical: classes.meterCritical,
+            warning: classes.meterWarning,
+            none: '',
+          }[severity];
+
+          return (
+            <ButtonBase
+              key={check.id}
+              focusRipple
+              aria-pressed={selected}
+              className={`${classes.tile} ${
+                selected ? classes.tileSelected : ''
+              }`}
+              onClick={() => onSelect(selected ? null : check.id)}
+            >
+              <Typography component="div" variant="subtitle2">
+                <strong>{check.name}</strong>
+              </Typography>
+
+              <Box display="flex" alignItems="baseline" style={{ gap: 6 }}>
+                <Typography component="span" className={classes.tilePct}>
+                  {pct}%
+                </Typography>
+                <Typography
+                  component="span"
+                  variant="caption"
+                  className={classes.subtle}
+                >
+                  passing
+                </Typography>
+              </Box>
+
+              <Box
+                className={classes.meter}
+                role="img"
+                aria-label={`${check.failing} of ${check.total} components failing`}
+              >
+                <Box
+                  className={`${classes.meterFill} ${fillClass}`}
+                  style={{
+                    width: check.total
+                      ? `${(check.failing / check.total) * 100}%`
+                      : 0,
+                  }}
+                />
+              </Box>
+
+              <Typography
+                component="span"
+                variant="caption"
+                className={classes.tabular}
+              >
+                {check.failing} of {check.total} failing
+              </Typography>
+            </ButtonBase>
+          );
+        })}
+      </div>
+    </Box>
+  );
+};

--- a/plugins/tech-insights-overview/src/components/FailuresTable.tsx
+++ b/plugins/tech-insights-overview/src/components/FailuresTable.tsx
@@ -1,0 +1,103 @@
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import { Link } from '@backstage/core-components';
+import type { FailingEntity } from '../useTechInsightsOverview';
+import { entityHref } from '../links';
+import { entitySeverity, useOverviewStyles } from '../styles';
+import { OwnerGlyph } from './OwnerGlyph';
+
+/**
+ * Components with at least one failing check, worst first. The count reads
+ * "N of M", not "N/M" — a bare fraction is ambiguous when other views show
+ * passing/total in the same shape.
+ */
+export const FailuresTable = ({
+  entities,
+  selectedCheckId,
+}: {
+  entities: FailingEntity[];
+  selectedCheckId: string | null;
+}) => {
+  const classes = useOverviewStyles();
+
+  if (entities.length === 0) {
+    return (
+      <Typography variant="body2" className={classes.empty}>
+        No components match these filters.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box className={classes.tableScroll}>
+      <Table size="small" className={classes.table}>
+        <TableHead>
+          <TableRow>
+            <TableCell className={classes.tableHeadCell}>Component</TableCell>
+            <TableCell className={classes.tableHeadCell}>Owner</TableCell>
+            <TableCell className={classes.tableHeadCell}>
+              Failing checks
+            </TableCell>
+            <TableCell className={classes.tableHeadCell} align="right">
+              Failing
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {entities.map(entity => {
+            const severity = entitySeverity(entity.failing);
+            const stripeClass = {
+              critical: classes.stripeCritical,
+              warning: classes.stripeWarning,
+              none: '',
+            }[severity];
+
+            return (
+              <TableRow key={entity.ref}>
+                <TableCell>
+                  <Box className={classes.componentCell}>
+                    <span className={`${classes.stripe} ${stripeClass}`} />
+                    <Link to={entityHref(entity.ref)}>{entity.name}</Link>
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  <Box className={classes.ownerCell}>
+                    <OwnerGlyph kind={entity.ownerKind} />
+                    <Typography component="span" className={classes.ownerName}>
+                      {entity.owner}
+                    </Typography>
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  <Box className={classes.chips}>
+                    {entity.failedCheckNames.map((name, i) => (
+                      <Chip
+                        key={entity.failedCheckIds[i]}
+                        label={name}
+                        size="small"
+                        color={
+                          selectedCheckId === entity.failedCheckIds[i]
+                            ? 'primary'
+                            : 'default'
+                        }
+                      />
+                    ))}
+                  </Box>
+                </TableCell>
+                <TableCell align="right" className={classes.tabular}>
+                  {entity.failing} of {entity.total}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};

--- a/plugins/tech-insights-overview/src/components/OwnerBars.tsx
+++ b/plugins/tech-insights-overview/src/components/OwnerBars.tsx
@@ -1,0 +1,84 @@
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import type { OwnerSummary } from '../useTechInsightsOverview';
+import { OWNER_BUDGET, useOverviewStyles } from '../styles';
+import { OwnerGlyph } from './OwnerGlyph';
+
+/** What a bar's number is counting. The budget is defined on failing checks, so it
+ *  only applies when that is what the bars measure. */
+export type OwnerBarsUnit = 'checks' | 'components';
+
+/**
+ * Failing checks (or, scoped to one check, failing components) per owner — the
+ * accountability axis the per-check view lacks.
+ *
+ * A single series, so one hue and no legend: the heading names what the bars are. Red
+ * only above the failing-checks budget, and never when the unit is components — a
+ * budget of checks applied to a count of components inverted the red/grey signal
+ * against what the on-screen legend claimed.
+ */
+export const OwnerBars = ({
+  owners,
+  highlight,
+  unit,
+}: {
+  owners: OwnerSummary[];
+  /** ownerRef to emphasise, or null for no emphasis. */
+  highlight: string | null;
+  unit: OwnerBarsUnit;
+}) => {
+  const classes = useOverviewStyles();
+
+  if (owners.length === 0) {
+    return (
+      <Typography variant="body2" className={classes.empty}>
+        Nothing failing.
+      </Typography>
+    );
+  }
+
+  const max = Math.max(1, ...owners.map(o => o.failing));
+
+  return (
+    <Box className={classes.bars}>
+      {owners.map(owner => {
+        const breached = unit === 'checks' && owner.failing > OWNER_BUDGET;
+        const dimmed = highlight !== null && highlight !== owner.ownerRef;
+        /* The tooltip keeps the kind in words — the glyph carries it visually. */
+        const described =
+          owner.ownerKind === 'user' ? `${owner.owner} (user)` : owner.owner;
+        const noun = unit === 'checks' ? 'failing check' : 'failing component';
+        return (
+          <Box
+            key={owner.ownerRef}
+            className={classes.barRow}
+            style={dimmed ? { opacity: 0.4 } : undefined}
+            title={`${described}: ${owner.failing} ${noun}${
+              owner.failing === 1 ? '' : 's'
+            } across ${owner.components} component${
+              owner.components === 1 ? '' : 's'
+            }`}
+          >
+            <Box className={classes.ownerCell}>
+              <OwnerGlyph kind={owner.ownerKind} />
+              <Typography component="span" className={classes.barLabel}>
+                {owner.owner}
+              </Typography>
+            </Box>
+            <Box className={classes.barTrack}>
+              <Box
+                className={`${classes.barFill} ${
+                  breached ? classes.barFillBreach : ''
+                }`}
+                style={{ width: `${(owner.failing / max) * 100}%` }}
+              />
+            </Box>
+            <Typography component="span" className={classes.barValue}>
+              {owner.failing}
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};

--- a/plugins/tech-insights-overview/src/components/OwnerGlyph.tsx
+++ b/plugins/tech-insights-overview/src/components/OwnerGlyph.tsx
@@ -1,0 +1,26 @@
+import PeopleOutlined from '@material-ui/icons/PeopleOutlined';
+import PersonOutlined from '@material-ui/icons/PersonOutlined';
+import { useOverviewStyles } from '../styles';
+
+/**
+ * A bare monochrome glyph saying whether an owner is a team or a person — the
+ * design system's icon style (marks stand directly on the surface, no well).
+ *
+ * `titleAccess` gives the glyph an accessible name, so the distinction never
+ * rests on shape alone. An unparseable owner (e.g. a bare email address) gets
+ * no glyph rather than a wrong one.
+ */
+export const OwnerGlyph = ({
+  kind,
+}: {
+  kind: 'group' | 'user' | 'unknown';
+}) => {
+  const classes = useOverviewStyles();
+  if (kind === 'user') {
+    return <PersonOutlined className={classes.ownerIcon} titleAccess="user" />;
+  }
+  if (kind === 'group') {
+    return <PeopleOutlined className={classes.ownerIcon} titleAccess="group" />;
+  }
+  return null;
+};

--- a/plugins/tech-insights-overview/src/components/SummaryBand.tsx
+++ b/plugins/tech-insights-overview/src/components/SummaryBand.tsx
@@ -1,0 +1,50 @@
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { useOverviewStyles } from '../styles';
+
+/**
+ * The one number worth reading first, as a peer section beside the check
+ * tiles. Components with no check results yet are excluded from scoring
+ * rather than counted as passing, and mentioned only when there are any.
+ */
+export const SummaryBand = ({
+  fullyPassing,
+  scored,
+  unscored,
+}: {
+  fullyPassing: number;
+  scored: number;
+  unscored: number;
+}) => {
+  const classes = useOverviewStyles();
+
+  return (
+    <Box className={classes.summary}>
+      <Typography variant="h6">Fully passing</Typography>
+      <Box className={classes.summaryCard}>
+        <Box className={classes.heroFigure}>
+          <Typography component="div" className={classes.heroNumber}>
+            {fullyPassing}
+          </Typography>
+          <Typography
+            component="div"
+            variant="body2"
+            className={classes.subtle}
+          >
+            of {scored} components
+          </Typography>
+        </Box>
+        {unscored > 0 && (
+          <Typography
+            variant="caption"
+            component="div"
+            className={classes.subtle}
+          >
+            {unscored} more component{unscored === 1 ? ' has' : 's have'} no
+            check results yet and {unscored === 1 ? 'is' : 'are'} not counted.
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/tech-insights-overview/src/index.ts
+++ b/plugins/tech-insights-overview/src/index.ts
@@ -1,0 +1,13 @@
+export { TechInsightsOverviewPage } from './TechInsightsOverviewPage';
+export { rootRouteRef } from './routes';
+export {
+  useTechInsightsOverview,
+  aggregateInsights,
+} from './useTechInsightsOverview';
+export type {
+  Aggregate,
+  BulkCheckResponse,
+  CheckSummary,
+  FailingEntity,
+  OwnerSummary,
+} from './useTechInsightsOverview';

--- a/plugins/tech-insights-overview/src/links.test.ts
+++ b/plugins/tech-insights-overview/src/links.test.ts
@@ -1,0 +1,15 @@
+import { entityHref } from './links';
+
+describe('entityHref', () => {
+  it('links to the component catalog page', () => {
+    expect(entityHref('component:default/my-service')).toBe(
+      '/catalog/default/component/my-service',
+    );
+  });
+
+  it('lowercases the kind and keeps the namespace', () => {
+    expect(entityHref('Component:team-x/api')).toBe(
+      '/catalog/team-x/component/api',
+    );
+  });
+});

--- a/plugins/tech-insights-overview/src/links.ts
+++ b/plugins/tech-insights-overview/src/links.ts
@@ -1,0 +1,11 @@
+import { parseEntityRef } from '@backstage/catalog-model';
+
+/**
+ * A failing row links to the component's catalog page — the one destination
+ * every Backstage instance has. Whether an entity page mounts a tech-insights
+ * tab is a host-app layout decision this plugin cannot know.
+ */
+export const entityHref = (ref: string) => {
+  const { kind, namespace, name } = parseEntityRef(ref);
+  return `/catalog/${namespace}/${kind.toLocaleLowerCase('en-US')}/${name}`;
+};

--- a/plugins/tech-insights-overview/src/routes.ts
+++ b/plugins/tech-insights-overview/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'tech-insights-overview',
+});

--- a/plugins/tech-insights-overview/src/setupTests.ts
+++ b/plugins/tech-insights-overview/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/plugins/tech-insights-overview/src/styles.ts
+++ b/plugins/tech-insights-overview/src/styles.ts
@@ -1,0 +1,258 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+/**
+ * How red a check or a component is allowed to look. A quarter of the catalog
+ * failing a check is a standard nobody is meeting; anything else failing is a
+ * warning; zero stays neutral.
+ */
+const CRITICAL_FAILURE_RATE = 0.25;
+/** A component failing this many checks reads as critical, not warning. */
+const CRITICAL_FAILING_CHECKS = 3;
+/** An owner over this many failing checks gets a red bar. */
+export const OWNER_BUDGET = 5;
+
+export type Severity = 'none' | 'warning' | 'critical';
+
+export const checkSeverity = (failing: number, total: number): Severity => {
+  if (failing === 0 || total === 0) return 'none';
+  return failing / total >= CRITICAL_FAILURE_RATE ? 'critical' : 'warning';
+};
+
+export const entitySeverity = (failing: number): Severity => {
+  if (failing === 0) return 'none';
+  return failing >= CRITICAL_FAILING_CHECKS ? 'critical' : 'warning';
+};
+
+/** Layout-only styles — colors, fonts, and radii come from the host theme. */
+export const useOverviewStyles = makeStyles(theme => {
+  const border = `1px solid ${theme.palette.divider}`;
+  return {
+    panel: {
+      backgroundColor: theme.palette.background.paper,
+      border,
+      borderRadius: theme.shape.borderRadius,
+    },
+    panelHead: {
+      padding: theme.spacing(1.75, 2),
+      borderBottom: border,
+      display: 'flex',
+      alignItems: 'baseline',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1.5),
+      flexWrap: 'wrap',
+    },
+    tableHeadCell: {
+      color: theme.palette.text.secondary,
+      fontWeight: 600,
+      whiteSpace: 'nowrap',
+    },
+    subtle: { color: theme.palette.text.secondary },
+    tabular: { fontVariantNumeric: 'tabular-nums' },
+
+    /* Top row: the fully-passing stat and the check tiles as peer sections,
+       separated by a vertical divider. */
+    topRow: {
+      display: 'flex',
+      alignItems: 'stretch',
+      gap: theme.spacing(3),
+      [theme.breakpoints.down('sm')]: { flexDirection: 'column' },
+    },
+    topRowTiles: {
+      flex: '1 1 0',
+      minWidth: 0,
+    },
+    summary: {
+      flex: '0 0 auto',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+    /* Sized and styled like a check tile so the row reads as one family. */
+    summaryCard: {
+      flex: '1 1 auto',
+      minWidth: 200,
+      padding: theme.spacing(1.75),
+      backgroundColor: theme.palette.background.paper,
+      border,
+      borderRadius: theme.shape.borderRadius,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      gap: theme.spacing(1),
+    },
+    heroFigure: {
+      display: 'flex',
+      alignItems: 'baseline',
+      gap: theme.spacing(1),
+    },
+    heroNumber: {
+      fontWeight: 600,
+      fontSize: '2.75rem',
+      lineHeight: 1,
+      fontVariantNumeric: 'tabular-nums',
+    },
+
+    /* Check tiles: one row, scrolled by the arrows in the header */
+    tilesHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1.5),
+      marginBottom: theme.spacing(1),
+    },
+    tilesArrows: {
+      display: 'flex',
+      gap: theme.spacing(1),
+    },
+    tilesScroller: {
+      display: 'flex',
+      gap: theme.spacing(1.5),
+      overflowX: 'auto',
+      /* The arrows are the affordance; a scrollbar under a card row reads as
+         clutter. Trackpads and touch still scroll it directly. */
+      scrollbarWidth: 'none',
+      msOverflowStyle: 'none',
+      '&::-webkit-scrollbar': { display: 'none' },
+    },
+    tile: {
+      flex: '0 0 220px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      justifyContent: 'flex-start',
+      gap: theme.spacing(1),
+      textAlign: 'left',
+      padding: theme.spacing(1.75),
+      backgroundColor: theme.palette.background.paper,
+      border,
+      borderRadius: theme.shape.borderRadius,
+      '&:hover': { borderColor: theme.palette.text.secondary },
+    },
+    tileSelected: {
+      borderColor: theme.palette.primary.main,
+      boxShadow: `inset 0 0 0 1px ${theme.palette.primary.main}`,
+      backgroundColor: theme.palette.action.selected,
+      '&:hover': { borderColor: theme.palette.primary.main },
+    },
+    tilePct: {
+      fontWeight: 600,
+      fontSize: '1.75rem',
+      lineHeight: 1,
+      fontVariantNumeric: 'tabular-nums',
+    },
+
+    /* Meter: neutral track, colored only when it matters */
+    meter: {
+      height: 6,
+      position: 'relative',
+      overflow: 'hidden',
+      backgroundColor: theme.palette.divider,
+      borderRadius: theme.shape.borderRadius,
+    },
+    meterFill: {
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      backgroundColor:
+        theme.palette.type === 'light'
+          ? theme.palette.grey[400]
+          : theme.palette.grey[700],
+    },
+    meterWarning: { backgroundColor: theme.palette.warning.main },
+    meterCritical: { backgroundColor: theme.palette.error.main },
+
+    /* Filters */
+    filters: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: theme.spacing(2),
+      padding: theme.spacing(2, 2, 1.5),
+      borderBottom: border,
+    },
+    filter: { minWidth: 170 },
+    resultCount: {
+      marginLeft: 'auto',
+      color: theme.palette.text.secondary,
+    },
+
+    /* Table */
+    tableScroll: { overflowX: 'auto' },
+    table: { minWidth: 680 },
+    componentCell: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+    },
+    stripe: {
+      width: 3,
+      height: 22,
+      flex: '0 0 3px',
+      backgroundColor: theme.palette.divider,
+    },
+    stripeWarning: { backgroundColor: theme.palette.warning.main },
+    stripeCritical: { backgroundColor: theme.palette.error.main },
+    ownerCell: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 4,
+      minWidth: 0,
+    },
+    ownerIcon: {
+      fontSize: 14,
+      flex: '0 0 auto',
+      color: theme.palette.text.secondary,
+    },
+    ownerName: {
+      fontSize: '0.8rem',
+      color: theme.palette.text.secondary,
+    },
+    chips: { display: 'flex', flexWrap: 'wrap', gap: 4 },
+
+    /* Owner bars: one owner per row — bars answer "who's worst" by length
+       comparison down a single column, so they never flow into columns. */
+    bars: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 2,
+      padding: theme.spacing(1.5, 2),
+    },
+    barRow: {
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, 10.5rem) minmax(0, 1fr) 2.5rem',
+      alignItems: 'center',
+      gap: theme.spacing(1.25),
+    },
+    barLabel: {
+      fontSize: '0.8rem',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    barTrack: { height: 14, position: 'relative' },
+    barFill: {
+      height: 14,
+      borderRadius: '0 4px 4px 0',
+      minWidth: 2,
+      backgroundColor:
+        theme.palette.type === 'light'
+          ? theme.palette.grey[400]
+          : theme.palette.grey[700],
+    },
+    barFillBreach: { backgroundColor: theme.palette.error.main },
+    barValue: {
+      textAlign: 'right',
+      fontSize: '0.8rem',
+      fontVariantNumeric: 'tabular-nums',
+      color: theme.palette.text.secondary,
+    },
+
+    empty: {
+      padding: theme.spacing(4, 2),
+      textAlign: 'center',
+      color: theme.palette.text.secondary,
+    },
+    sectionGap: { marginTop: theme.spacing(3) },
+  };
+});

--- a/plugins/tech-insights-overview/src/useTechInsightsOverview.test.ts
+++ b/plugins/tech-insights-overview/src/useTechInsightsOverview.test.ts
@@ -1,0 +1,163 @@
+import type { Entity } from '@backstage/catalog-model';
+import type { CheckResult } from '@backstage-community/plugin-tech-insights-common';
+import {
+  aggregateInsights,
+  type BulkCheckResponse,
+} from './useTechInsightsOverview';
+
+const component = (name: string, owner?: string): Entity => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name, namespace: 'default' },
+  spec: owner ? { owner } : {},
+});
+
+const result = (id: string, passed: boolean): CheckResult =>
+  ({
+    check: { id, name: `Check ${id}` },
+    facts: {},
+    result: passed,
+  } as unknown as CheckResult);
+
+// The plugin treats `result: false` as failed via the injected predicate.
+const isFailed = (r: CheckResult) => (r as any).result === false;
+
+describe('aggregateInsights', () => {
+  it('aggregates failures by entity, check, and owner, worst first', () => {
+    const items = [
+      component('api', 'team-a'),
+      component('web', 'team-b'),
+      component('db', 'team-a'),
+    ];
+    const bulk: BulkCheckResponse = [
+      {
+        entity: 'component:default/api',
+        results: [result('hasOwner', false), result('hasDocs', false)],
+      },
+      {
+        entity: 'component:default/web',
+        results: [result('hasOwner', false), result('hasDocs', true)],
+      },
+      {
+        entity: 'component:default/db',
+        results: [result('hasOwner', true), result('hasDocs', true)],
+      },
+    ];
+
+    const aggregate = aggregateInsights(items, bulk, isFailed);
+
+    expect(aggregate.scored).toBe(3);
+    expect(aggregate.fullyPassing).toBe(1);
+    expect(aggregate.unscored).toBe(0);
+
+    expect(aggregate.entities.map(e => e.name)).toEqual(['api', 'web']);
+    expect(aggregate.entities[0]).toMatchObject({
+      name: 'api',
+      failing: 2,
+      total: 2,
+      failedCheckIds: ['hasOwner', 'hasDocs'],
+    });
+
+    expect(aggregate.checks).toEqual([
+      { id: 'hasOwner', name: 'Check hasOwner', failing: 2, total: 3 },
+      { id: 'hasDocs', name: 'Check hasDocs', failing: 1, total: 3 },
+    ]);
+
+    expect(aggregate.owners).toEqual([
+      {
+        ownerRef: 'group:default/team-a',
+        owner: 'team-a',
+        ownerKind: 'group',
+        failing: 2,
+        components: 1,
+      },
+      {
+        ownerRef: 'group:default/team-b',
+        owner: 'team-b',
+        ownerKind: 'group',
+        failing: 1,
+        components: 1,
+      },
+    ]);
+  });
+
+  it('counts components with no results as unscored, not passing', () => {
+    const items = [component('api', 'team-a'), component('new', 'team-a')];
+    const bulk: BulkCheckResponse = [
+      { entity: 'component:default/api', results: [result('hasOwner', true)] },
+      { entity: 'component:default/new', results: [] },
+    ];
+
+    const aggregate = aggregateInsights(items, bulk, isFailed);
+
+    expect(aggregate.scored).toBe(1);
+    expect(aggregate.fullyPassing).toBe(1);
+    expect(aggregate.unscored).toBe(1);
+  });
+
+  it('keys owners by canonical ref so a group and user sharing a name stay separate', () => {
+    const items = [
+      component('api', 'group:default/platform'),
+      component('web', 'user:default/platform'),
+    ];
+    const bulk: BulkCheckResponse = [
+      {
+        entity: 'component:default/api',
+        results: [result('hasOwner', false)],
+      },
+      {
+        entity: 'component:default/web',
+        results: [result('hasOwner', false)],
+      },
+    ];
+
+    const aggregate = aggregateInsights(items, bulk, isFailed);
+
+    expect(aggregate.owners).toHaveLength(2);
+    expect(aggregate.owners.map(o => o.ownerKind).sort()).toEqual([
+      'group',
+      'user',
+    ]);
+  });
+
+  it('uses an unowned sentinel when spec.owner is missing', () => {
+    const items = [component('api')];
+    const bulk: BulkCheckResponse = [
+      { entity: 'component:default/api', results: [result('hasOwner', false)] },
+    ];
+
+    const aggregate = aggregateInsights(items, bulk, isFailed);
+
+    expect(aggregate.entities[0]).toMatchObject({
+      ownerRef: 'unowned',
+      owner: 'unowned',
+      ownerKind: 'unknown',
+    });
+  });
+
+  it('keeps an unparseable owner verbatim', () => {
+    // An empty name makes parseEntityRef throw, exercising the fallback.
+    const items = [component('api', 'group:default/')];
+    const bulk: BulkCheckResponse = [
+      { entity: 'component:default/api', results: [result('hasOwner', false)] },
+    ];
+
+    const aggregate = aggregateInsights(items, bulk, isFailed);
+
+    expect(aggregate.entities[0].owner).toBe('group:default/');
+    expect(aggregate.entities[0].ownerKind).toBe('unknown');
+  });
+
+  it('falls back to the ref when the entity is not in the catalog page', () => {
+    const bulk: BulkCheckResponse = [
+      {
+        entity: 'component:default/ghost',
+        results: [result('hasOwner', false)],
+      },
+    ];
+
+    const aggregate = aggregateInsights([], bulk, isFailed);
+
+    expect(aggregate.entities[0].name).toBe('component:default/ghost');
+  });
+});

--- a/plugins/tech-insights-overview/src/useTechInsightsOverview.ts
+++ b/plugins/tech-insights-overview/src/useTechInsightsOverview.ts
@@ -1,0 +1,238 @@
+import { useMemo } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { techInsightsApiRef } from '@backstage-community/plugin-tech-insights-react';
+import type { CheckResult } from '@backstage-community/plugin-tech-insights-common';
+import {
+  getCompoundEntityRef,
+  parseEntityRef,
+  stringifyEntityRef,
+  type Entity,
+} from '@backstage/catalog-model';
+
+/** A component with at least one failing check. */
+export type FailingEntity = {
+  ref: string;
+  name: string;
+  /**
+   * Canonical owner ref (e.g. `group:default/platform`) — the identity everything
+   * keys on. `group:default/platform` and `user:default/platform` are different
+   * owners that happen to share a display name; keying by the short name merged
+   * them, so a team got blamed for a person's failures.
+   */
+  ownerRef: string;
+  /** Short display label for spec.owner — the group or user name, not the full ref. */
+  owner: string;
+  ownerKind: 'group' | 'user' | 'unknown';
+  failing: number;
+  /** Checks with results for this component, not all configured checks. */
+  total: number;
+  failedCheckIds: string[];
+  failedCheckNames: string[];
+};
+
+export type CheckSummary = {
+  id: string;
+  name: string;
+  failing: number;
+  total: number;
+};
+
+export type OwnerSummary = {
+  ownerRef: string;
+  owner: string;
+  ownerKind: 'group' | 'user' | 'unknown';
+  /** Total failing checks across this owner's components. */
+  failing: number;
+  /** How many of their components have at least one failure. */
+  components: number;
+};
+
+export type Aggregate = {
+  entities: FailingEntity[];
+  checks: CheckSummary[];
+  owners: OwnerSummary[];
+  fullyPassing: number;
+  /** Components with at least one check result. */
+  scored: number;
+  /** Components with no check results yet — not counted as passing or failing. */
+  unscored: number;
+};
+
+/** Bulk check response shape, kept local so the hook and its tests agree. */
+export type BulkCheckResponse = {
+  entity: string;
+  results: CheckResult[];
+}[];
+
+/** Sentinel ref for entities with no spec.owner. A real group named "unowned" would
+ *  stringify to `group:default/unowned`, so this bare form cannot collide. */
+const UNOWNED_REF = 'unowned';
+
+/**
+ * spec.owner reduced to an identity plus something a column can show. The kind is
+ * carried through so the UI can say whether an owner is a team or a person.
+ */
+const readOwner = (
+  entity: Entity | undefined,
+): Pick<FailingEntity, 'ownerRef' | 'owner' | 'ownerKind'> => {
+  const raw = entity?.spec?.owner;
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { ownerRef: UNOWNED_REF, owner: 'unowned', ownerKind: 'unknown' };
+  }
+  try {
+    const compound = parseEntityRef(raw, {
+      defaultKind: 'group',
+      defaultNamespace: 'default',
+    });
+    return {
+      ownerRef: stringifyEntityRef(compound),
+      owner: compound.name,
+      ownerKind: compound.kind.toLowerCase() === 'user' ? 'user' : 'group',
+    };
+  } catch {
+    // An owner that is not a parseable ref is still worth showing verbatim; the raw
+    // string is its own identity.
+    return { ownerRef: raw, owner: raw, ownerKind: 'unknown' };
+  }
+};
+
+/**
+ * Turn a catalog page plus a bulk check response into the overview aggregate.
+ *
+ * Exported separately from the hook so the aggregation can be tested without an
+ * ApiProvider: everything here is pure.
+ */
+export const aggregateInsights = (
+  items: Entity[],
+  bulk: BulkCheckResponse,
+  isFailed: (result: CheckResult) => boolean,
+): Aggregate => {
+  const byRef = new Map<string, Entity>(
+    items.map(e => [stringifyEntityRef(e), e]),
+  );
+
+  const checkTotals = new Map<
+    string,
+    { name: string; failing: number; total: number }
+  >();
+  const ownerTotals = new Map<string, OwnerSummary>();
+  const entities: FailingEntity[] = [];
+  let fullyPassing = 0;
+  let scored = 0;
+  let unscored = 0;
+
+  for (const { entity: ref, results } of bulk) {
+    if (results.length === 0) {
+      // No facts collected yet — not "passing", but not failing either.
+      unscored += 1;
+      continue;
+    }
+    const entity = byRef.get(ref);
+
+    scored += 1;
+    let failing = 0;
+    const failedCheckIds: string[] = [];
+    const failedCheckNames: string[] = [];
+
+    for (const result of results) {
+      const failed = isFailed(result);
+      if (failed) {
+        failing += 1;
+        failedCheckIds.push(result.check.id);
+        failedCheckNames.push(result.check.name);
+      }
+      const existing = checkTotals.get(result.check.id) ?? {
+        name: result.check.name,
+        failing: 0,
+        total: 0,
+      };
+      existing.total += 1;
+      if (failed) existing.failing += 1;
+      checkTotals.set(result.check.id, existing);
+    }
+
+    if (failing === 0) {
+      fullyPassing += 1;
+      continue;
+    }
+
+    const { ownerRef, owner, ownerKind } = readOwner(entity);
+    entities.push({
+      ref,
+      name: entity?.metadata.name ?? ref,
+      ownerRef,
+      owner,
+      ownerKind,
+      failing,
+      total: results.length,
+      failedCheckIds,
+      failedCheckNames,
+    });
+
+    const tally = ownerTotals.get(ownerRef) ?? {
+      ownerRef,
+      owner,
+      ownerKind,
+      failing: 0,
+      components: 0,
+    };
+    tally.failing += failing;
+    tally.components += 1;
+    ownerTotals.set(ownerRef, tally);
+  }
+
+  return {
+    // Worst first; a name-sorted list is one nobody acts on.
+    entities: entities.sort(
+      (a, b) => b.failing - a.failing || a.name.localeCompare(b.name),
+    ),
+    checks: [...checkTotals.entries()]
+      .map(([id, v]) => ({ id, ...v }))
+      .sort((a, b) => b.failing - a.failing || a.name.localeCompare(b.name)),
+    owners: [...ownerTotals.values()].sort(
+      (a, b) => b.failing - a.failing || a.owner.localeCompare(b.owner),
+    ),
+    fullyPassing,
+    scored,
+    unscored,
+  };
+};
+
+/**
+ * Catalog-wide check results, aggregated by check and by owner.
+ *
+ * Components only: scoring logical groupings like Systems double-counts the
+ * components they contain while having no source location, image or docs of
+ * their own to satisfy a check.
+ */
+export const useTechInsightsOverview = () => {
+  const catalogApi = useApi(catalogApiRef);
+  const techInsights = useApi(techInsightsApiRef);
+
+  const state = useAsync(async () => {
+    const { items } = await catalogApi.getEntities({
+      filter: [{ kind: 'component' }],
+      fields: [
+        'kind',
+        'metadata.name',
+        'metadata.namespace',
+        'spec.owner',
+        'spec.type',
+      ],
+    });
+    const refs = items.map(getCompoundEntityRef);
+    const bulk = refs.length ? await techInsights.runBulkChecks(refs) : [];
+    return { items, bulk: bulk as BulkCheckResponse };
+  }, [catalogApi, techInsights]);
+
+  const aggregate = useMemo<Aggregate | undefined>(() => {
+    if (!state.value) return undefined;
+    return aggregateInsights(state.value.items, state.value.bulk, result =>
+      techInsights.isCheckResultFailed(result),
+    );
+  }, [state.value, techInsights]);
+
+  return { ...state, aggregate };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,6 +2006,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.28.6":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -2088,6 +2095,140 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage-community/plugin-tech-insights-backend-module-jsonfc@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@backstage-community/plugin-tech-insights-backend-module-jsonfc@npm:0.9.0"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage-community/plugin-tech-insights-node": "npm:^2.8.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-catalog-node": "npm:^2.2.1"
+    "@backstage/types": "npm:^1.2.2"
+    ajv: "npm:^8.10.0"
+    json-rules-engine: "npm:^7.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+  checksum: 10c0/85944b5039ffd8438eee806d299ec37d3e0644f1a952ade5cb67cebdb8249d2a80d58271627a55cbc7e03de746ae0e9f0909c26c659accd61ffec20f3b0651fc
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-insights-backend@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@backstage-community/plugin-tech-insights-backend@npm:3.0.1"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage-community/plugin-tech-insights-node": "npm:^2.8.0"
+    "@backstage/backend-defaults": "npm:^0.17.1"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/backend-test-utils": "npm:^1.11.3"
+    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/luxon": "npm:^3.0.0"
+    express: "npm:^4.17.1"
+    express-promise-router: "npm:^4.1.0"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-limit: "npm:^3.1.0"
+    semver: "npm:^7.5.3"
+    yn: "npm:^4.0.0"
+  checksum: 10c0/c91da413ba556f7128227485eb04bcabd7f2ccdeeb80665de12a5d9aed5c6dfd0d85ed94188bd722d97b44af5f27fcb94aa2b73dd1b3289809ad6b1173929532
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-insights-common@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@backstage-community/plugin-tech-insights-common@npm:0.10.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/core-plugin-api": "npm:^1.12.6"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/luxon": "npm:^3.0.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    luxon: "npm:^3.0.0"
+    qs: "npm:^6.12.3"
+  checksum: 10c0/de8776998a596591c685b22f457d6ab0944dbe48fe752e2446a8614e2174f9603cfd316604b3e35b0fa4513a3332ee4c638312be696129ec88a89b79dccf6a92
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-insights-node@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@backstage-community/plugin-tech-insights-node@npm:2.8.0"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/luxon": "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+  checksum: 10c0/725ba040e68250d622124e0ba98ff2a7ae4a541953d79b1aa3292abf1b17020276ee7a6a2ec599119bd7a74bbddc1f0bad3b0e74d21cabb0dc78de44b6d5f9d4
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-insights-react@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@backstage-community/plugin-tech-insights-react@npm:1.6.0"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/core-plugin-api": "npm:^1.12.6"
+    "@backstage/filter-predicates": "npm:^0.1.3"
+    "@backstage/frontend-plugin-api": "npm:^0.17.0"
+    "@backstage/plugin-catalog-react": "npm:^3.0.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/a9a956ef0ade1dbbb4ce5dc4a2e636420c397f33ee8e193d1768156988c9d44a68dbf15f94c2b353795220d562e81dd7ca65d46443ee500b09a05d9b8afdc08e
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-insights@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@backstage-community/plugin-tech-insights@npm:1.4.0"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage-community/plugin-tech-insights-react": "npm:^1.6.0"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/core-compat-api": "npm:^0.5.11"
+    "@backstage/core-components": "npm:^0.18.10"
+    "@backstage/core-plugin-api": "npm:^1.12.6"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.3"
+    "@backstage/frontend-plugin-api": "npm:^0.17.0"
+    "@backstage/plugin-catalog-react": "npm:^3.0.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.15.0"
+    "@material-table/exporters": "npm:^1.2.19"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react-use: "npm:^17.2.4"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 10c0/6d55bab56aabe29c187ffd1459a43061a251cf5e9722474421deb76146a1daabbc208c36d2baacbfcabafc8654bdf9a97ee6da8f54d9e90b39f81d1232e83cee
+  languageName: node
+  linkType: hard
+
 "@backstage/app-defaults@npm:^1.7.11":
   version: 1.7.11
   resolution: "@backstage/app-defaults@npm:1.7.11"
@@ -2126,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:^0.17.7":
+"@backstage/backend-defaults@npm:^0.17.1, @backstage/backend-defaults@npm:^0.17.7":
   version: 0.17.7
   resolution: "@backstage/backend-defaults@npm:0.17.7"
   dependencies:
@@ -2246,7 +2387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.10.0":
+"@backstage/backend-plugin-api@npm:^1.10.0, @backstage/backend-plugin-api@npm:^1.9.1":
   version: 1.10.0
   resolution: "@backstage/backend-plugin-api@npm:1.10.0"
   dependencies:
@@ -2267,7 +2408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-test-utils@npm:^1.11.6":
+"@backstage/backend-test-utils@npm:^1.11.3, @backstage/backend-test-utils@npm:^1.11.6":
   version: 1.11.6
   resolution: "@backstage/backend-test-utils@npm:1.11.6"
   dependencies:
@@ -2311,7 +2452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.16.1":
+"@backstage/catalog-client@npm:^1.15.1, @backstage/catalog-client@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/catalog-client@npm:1.16.1"
   dependencies:
@@ -2833,7 +2974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:^0.5.14":
+"@backstage/core-compat-api@npm:^0.5.11, @backstage/core-compat-api@npm:^0.5.14":
   version: 0.5.14
   resolution: "@backstage/core-compat-api@npm:0.5.14"
   dependencies:
@@ -2858,7 +2999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.18.13":
+"@backstage/core-components@npm:^0.18.10, @backstage/core-components@npm:^0.18.13":
   version: 0.18.13
   resolution: "@backstage/core-components@npm:0.18.13"
   dependencies:
@@ -2917,7 +3058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.12.9":
+"@backstage/core-plugin-api@npm:^1.12.6, @backstage/core-plugin-api@npm:^1.12.9":
   version: 1.12.9
   resolution: "@backstage/core-plugin-api@npm:1.12.9"
   dependencies:
@@ -3003,7 +3144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/filter-predicates@npm:^0.1.4":
+"@backstage/filter-predicates@npm:^0.1.3, @backstage/filter-predicates@npm:^0.1.4":
   version: 0.1.4
   resolution: "@backstage/filter-predicates@npm:0.1.4"
   dependencies:
@@ -3062,6 +3203,30 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/ee19823794719c430c263c2f2482f053366bf212f3b51de7cca13712e2786bd016f3b780c8d1ebdbe3b010c1559a3689a55290ae66acd71fbc18b9ecd34acacc
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.17.0":
+  version: 0.17.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d321dd4e37d655a2b1e5a4b50aa280d5d21e9b96dc674505bce2b35820c33e04926f89a9335c3f1ea658e4321d6480efb7ce75eb2729fbeeb07af40d426cd7be
   languageName: node
   linkType: hard
 
@@ -3638,7 +3803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^2.2.4":
+"@backstage/plugin-catalog-node@npm:^2.2.1, @backstage/plugin-catalog-node@npm:^2.2.4":
   version: 2.2.4
   resolution: "@backstage/plugin-catalog-node@npm:2.2.4"
   dependencies:
@@ -3662,7 +3827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:^3.2.1":
+"@backstage/plugin-catalog-react@npm:^3.0.0, @backstage/plugin-catalog-react@npm:^3.2.1":
   version: 3.2.1
   resolution: "@backstage/plugin-catalog-react@npm:3.2.1"
   dependencies:
@@ -5041,6 +5206,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/ui@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@backstage/ui@npm:0.15.0"
+  dependencies:
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/a7087cbc784458260c9064a534d7eb1ae506af7fe95537473bf1480916b53ff0bced26caa8bfd0aba14b3039ba584c0b7b3d6f6b58df0feaa1aa1fd4e394ff13
+  languageName: node
+  linkType: hard
+
 "@backstage/ui@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/ui@npm:0.17.1"
@@ -6118,6 +6310,32 @@ __metadata:
     "@backstage/core-plugin-api": "npm:^1.12.9"
     "@backstage/frontend-plugin-api": "npm:^0.18.0"
     "@backstage/frontend-test-utils": "npm:^0.6.3"
+    "@backstage/test-utils": "npm:^1.7.21"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@testing-library/jest-dom": "npm:^6.4.2"
+    "@testing-library/react": "npm:^14.2.1"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  languageName: unknown
+  linkType: soft
+
+"@globallogicuki/backstage-plugin-tech-insights-overview@workspace:^, @globallogicuki/backstage-plugin-tech-insights-overview@workspace:plugins/tech-insights-overview":
+  version: 0.0.0-use.local
+  resolution: "@globallogicuki/backstage-plugin-tech-insights-overview@workspace:plugins/tech-insights-overview"
+  dependencies:
+    "@backstage-community/plugin-tech-insights-common": "npm:^0.10.0"
+    "@backstage-community/plugin-tech-insights-react": "npm:^1.6.0"
+    "@backstage/catalog-model": "npm:^1.10.0"
+    "@backstage/cli": "npm:^0.36.5"
+    "@backstage/core-app-api": "npm:^1.20.4"
+    "@backstage/core-compat-api": "npm:^0.5.14"
+    "@backstage/core-components": "npm:^0.18.13"
+    "@backstage/core-plugin-api": "npm:^1.12.9"
+    "@backstage/frontend-plugin-api": "npm:^0.18.0"
+    "@backstage/frontend-test-utils": "npm:^0.6.3"
+    "@backstage/plugin-catalog-react": "npm:^3.2.1"
     "@backstage/test-utils": "npm:^1.7.21"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -7461,6 +7679,19 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/b423a6439caef27edca7cda36385add7740a727317ca5272b7600550054a7400a84f540caa292735520f57cd223f547298ce1c233e2c3d51c68df1c946c72151
+  languageName: node
+  linkType: hard
+
+"@material-table/exporters@npm:^1.2.19":
+  version: 1.2.21
+  resolution: "@material-table/exporters@npm:1.2.21"
+  dependencies:
+    filefy: "npm:^0.1.11"
+    jspdf: "npm:^4.0.0"
+    jspdf-autotable: "npm:^5.0.7"
+  peerDependencies:
+    "@material-table/core": "*"
+  checksum: 10c0/e8f2505bd72e9830a63b0e4f8bd318046e491698301837a6def693eaba5747c6b4cf6d496dbeee439e28c1173ca8e087e3a359e9dcd67db8de408765e832ced4
   languageName: node
   linkType: hard
 
@@ -13750,6 +13981,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pako@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "@types/pako@npm:2.0.4"
+  checksum: 10c0/5765bf8bc7e77ee141c454118f03e544b8f6cb51eb257d82dc5830feeab8cd00818af3a1eabefdfbe8dd3ae9916ed5403937bf1031a0ee51deea27fdf4dccdfb
+  languageName: node
+  linkType: hard
+
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
@@ -13800,6 +14038,13 @@ __metadata:
   version: 6.14.0
   resolution: "@types/qs@npm:6.14.0"
   checksum: 10c0/5b3036df6e507483869cdb3858201b2e0b64b4793dc4974f188caa5b5732f2333ab9db45c08157975054d3b070788b35088b4bc60257ae263885016ee2131310
+  languageName: node
+  linkType: hard
+
+"@types/raf@npm:^3.4.0":
+  version: 3.4.3
+  resolution: "@types/raf@npm:3.4.3"
+  checksum: 10c0/dea835f0daa399c51db9137f5337dc08a2b4a5f61f645658966ecabaebbbd0fd59551f384a1141e14e22a1cc5a591da7d4d88c60a525ad1399108b6dd2641d75
   languageName: node
   linkType: hard
 
@@ -15389,6 +15634,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
+    "@backstage-community/plugin-tech-insights": "npm:^1.4.0"
     "@backstage/cli": "npm:^0.36.5"
     "@backstage/core-components": "npm:^0.18.13"
     "@backstage/core-plugin-api": "npm:^1.12.9"
@@ -15417,6 +15663,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.9.6"
     "@backstage/ui": "npm:^0.17.1"
     "@globallogicuki/backstage-plugin-skills-marketplace": "workspace:^"
+    "@globallogicuki/backstage-plugin-tech-insights-overview": "workspace:^"
     "@globallogicuki/backstage-plugin-terraform": "npm:^0.11.7"
     "@globallogicuki/backstage-plugin-unleash": "workspace:^"
     "@material-ui/core": "npm:^4.12.2"
@@ -16008,6 +16255,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backend@workspace:packages/backend"
   dependencies:
+    "@backstage-community/plugin-tech-insights-backend": "npm:^3.0.1"
+    "@backstage-community/plugin-tech-insights-backend-module-jsonfc": "npm:^0.9.0"
     "@backstage/backend-defaults": "npm:^0.17.7"
     "@backstage/backend-plugin-api": "npm:^1.10.0"
     "@backstage/cli": "npm:^0.36.5"
@@ -16153,6 +16402,13 @@ __metadata:
   version: 0.1.5
   resolution: "base64-arraybuffer@npm:0.1.5"
   checksum: 10c0/90afdff8ecae0ea96709f8d65037585bcabddfb222bc8b46408b74b982a8322f36fe1f97468d84e6e18e01ac165ee1c6570bde6c8f9b4f64a3e9374885237a76
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10c0/3acac95c70f9406e87a41073558ba85b6be9dbffb013a3d2a710e3f2d534d506c911847d5d9be4de458af6362c676de0a5c4c2d7bdf4def502d00b313368e72f
   languageName: node
   linkType: hard
 
@@ -16918,6 +17174,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvg@npm:^3.0.11":
+  version: 3.0.11
+  resolution: "canvg@npm:3.0.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/raf": "npm:^3.4.0"
+    core-js: "npm:^3.8.3"
+    raf: "npm:^3.4.1"
+    regenerator-runtime: "npm:^0.13.7"
+    rgbcolor: "npm:^1.0.1"
+    stackblur-canvas: "npm:^2.0.0"
+    svg-pathdata: "npm:^6.0.3"
+  checksum: 10c0/03ea5b69e97a4a476ef5fc8455d0da2718bd68cd8ace3e42718176bf4b7dfd80eb1d0eba47dcd04b34ed9a0c5c8ed849ead0f364dad0e35369254a45d5e098c4
+  languageName: node
+  linkType: hard
+
 "catharsis@npm:^0.9.0":
   version: 0.9.0
   resolution: "catharsis@npm:0.9.0"
@@ -17247,6 +17519,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
+"clone@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "clone@npm:2.1.2"
+  checksum: 10c0/ed0601cd0b1606bc7d82ee7175b97e68d1dd9b91fd1250a3617b38d34a095f8ee0431d40a1a611122dcccb4f93295b4fdb94942aa763392b5fe44effa50c2d5e
   languageName: node
   linkType: hard
 
@@ -17846,6 +18125,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.6.0, core-js@npm:^3.8.3":
+  version: 3.50.0
+  resolution: "core-js@npm:3.50.0"
+  checksum: 10c0/1bfcfb1dbdf45b0b1428a9fdcb03697d1fc52c7e9bc336f804a86ff2c2705a301dca7d9d6636d09d49d60298183273b9321681baeaf330c78db5393bc73f3f6a
+  languageName: node
+  linkType: hard
+
 "core-js@npm:^3.6.5":
   version: 3.47.0
   resolution: "core-js@npm:3.47.0"
@@ -18114,6 +18400,15 @@ __metadata:
   dependencies:
     hyphenate-style-name: "npm:^1.0.3"
   checksum: 10c0/8bb042e8f7701a7edadc3cce5ce2d5cf41189631d7e2aed194d5a7059b25776dded2a0466cb9da1d1f3fc6c99dcecb51e45671148d073b8a2a71e34755152e52
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10c0/b2222d99d5daf7861ecddc050244fdce296fad74b000dcff6bdfb1eb16dc2ef0b9ffe2c1c965e3239bd05ebe9eadb6d5438a91592fa8648d27a338e827cf9048
   languageName: node
   linkType: hard
 
@@ -20190,6 +20485,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter2@npm:^6.4.4":
+  version: 6.4.9
+  resolution: "eventemitter2@npm:6.4.9"
+  checksum: 10c0/b2adf7d9f1544aa2d95ee271b0621acaf1e309d85ebcef1244fb0ebc7ab0afa6ffd5e371535d0981bc46195ad67fd6ff57a8d1db030584dee69aa5e371a27ea7
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^3.1.0":
   version: 3.1.2
   resolution: "eventemitter3@npm:3.1.2"
@@ -20579,6 +20881,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-png@npm:^6.2.0":
+  version: 6.4.0
+  resolution: "fast-png@npm:6.4.0"
+  dependencies:
+    "@types/pako": "npm:^2.0.3"
+    iobuffer: "npm:^5.3.2"
+    pako: "npm:^2.1.0"
+  checksum: 10c0/bca27a09d56a5ead536b11c1ddccf4fe44c7c0af88a8faefab6a397527d9c71b00c09b2055d0108807c438c50719dd2acbd7217ef88785b500888db26fa0358a
+  languageName: node
+  linkType: hard
+
 "fast-redact@npm:^2.0.0":
   version: 2.1.0
   resolution: "fast-redact@npm:2.1.0"
@@ -20718,6 +21031,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:^0.8.1":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
+  languageName: node
+  linkType: hard
+
 "fflate@npm:^0.8.2":
   version: 0.8.2
   resolution: "fflate@npm:0.8.2"
@@ -20770,6 +21090,13 @@ __metadata:
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
   checksum: 10c0/3b545e3a341d322d368e880e1c204ef55f1d45cdea65f7efc6c6ce9e0c4d22d802d5629320eb779d006fe59624ac17b0e848d83cc5af7cd101f206cb704f5519
+  languageName: node
+  linkType: hard
+
+"filefy@npm:^0.1.11":
+  version: 0.1.11
+  resolution: "filefy@npm:0.1.11"
+  checksum: 10c0/a051a78831963118c38c366de5a8b4777c5e51b8d625e444240b8c937f9d60b3054b61553f609c54bcece959794d9a108f0453697aba523aacce0c15799d3f99
   languageName: node
   linkType: hard
 
@@ -21998,6 +22325,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash-it@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "hash-it@npm:6.0.1"
+  checksum: 10c0/b5abe8f6f3d3040522ba0ecb64a34eda7de653bae6db19bb260dad2eeafe1b0be5e88dc57a7200d2ed2f6537dd9549597950cde6424e0dac31cfea438b49ec13
+  languageName: node
+  linkType: hard
+
 "hash.js@npm:^1.0.0, hash.js@npm:^1.0.3":
   version: 1.1.7
   resolution: "hash.js@npm:1.1.7"
@@ -22341,6 +22675,16 @@ __metadata:
     webpack:
       optional: true
   checksum: 10c0/4ae0ae48fec6337e4eb055e730e46340172ec1967bd383d897d03cb3c4e385a8128e8d5179c4658536b00e432c2d3f026d97eb5fdb4cf9dc710498d2e871b84e
+  languageName: node
+  linkType: hard
+
+"html2canvas@npm:^1.0.0-rc.5":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: "npm:^2.1.0"
+    text-segmentation: "npm:^1.0.3"
+  checksum: 10c0/6de86f75762b00948edf2ea559f16da0a1ec3facc4a8a7d3f35fcec59bb0c5970463478988ae3d9082152e0173690d46ebf4082e7ac803dd4817bae1d355c0db
   languageName: node
   linkType: hard
 
@@ -22866,6 +23210,13 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.0.0"
   checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
+"iobuffer@npm:^5.3.2":
+  version: 5.4.0
+  resolution: "iobuffer@npm:5.4.0"
+  checksum: 10c0/1b3f9a5ea158bc63f038b374b42832acdb9db13ea9cfa4ed78723f30894986442f6c033dff4ae2fdf34724bf0fe432e3b86c11ca82049568c58b8d7fb47a6ac2
   languageName: node
   linkType: hard
 
@@ -24533,6 +24884,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-rules-engine@npm:^7.0.0":
+  version: 7.3.1
+  resolution: "json-rules-engine@npm:7.3.1"
+  dependencies:
+    clone: "npm:^2.1.2"
+    eventemitter2: "npm:^6.4.4"
+    hash-it: "npm:^6.0.0"
+    jsonpath-plus: "npm:^10.3.0"
+  checksum: 10c0/2429358d7425232a2ccb830d0d3137e17c2b44218f772316efb98b9170945d1ae269798dd9f7af484b4b559e153d3c1de0a374dd3b41af58b0407171852b5cfe
+  languageName: node
+  linkType: hard
+
 "json-schema-compare@npm:^0.2.2":
   version: 0.2.2
   resolution: "json-schema-compare@npm:0.2.2"
@@ -24715,6 +25078,39 @@ __metadata:
     ms: "npm:^2.1.1"
     semver: "npm:^7.5.4"
   checksum: 10c0/6ca7f1e54886ea3bde7146a5a22b53847c46e25453c7f7307a69818b9a6ad48c390b2e59d5690fcfd03c529b01960060cc4bb0c686991d6edae2285dfd30f4ba
+  languageName: node
+  linkType: hard
+
+"jspdf-autotable@npm:^5.0.7":
+  version: 5.0.8
+  resolution: "jspdf-autotable@npm:5.0.8"
+  peerDependencies:
+    jspdf: ^2 || ^3 || ^4
+  checksum: 10c0/c5e695d6d31692b9d2c11d284948ad508fc3e616d0b555119451dfd307176bdd80c880459cef6fee9e7db5140272b6fa281ee0ffaeeffddca6bf2497b577b40e
+  languageName: node
+  linkType: hard
+
+"jspdf@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "jspdf@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+    canvg: "npm:^3.0.11"
+    core-js: "npm:^3.6.0"
+    dompurify: "npm:^3.3.1"
+    fast-png: "npm:^6.2.0"
+    fflate: "npm:^0.8.1"
+    html2canvas: "npm:^1.0.0-rc.5"
+  dependenciesMeta:
+    canvg:
+      optional: true
+    core-js:
+      optional: true
+    dompurify:
+      optional: true
+    html2canvas:
+      optional: true
+  checksum: 10c0/d905809b374de1060ab39ba4b1603935fcced314bef8f63f7fd272d3f96eff0b50a96e48d3c2063ac8e51b84a1442464ff2b037af13f54b082e456416da470b7
   languageName: node
   linkType: hard
 
@@ -28086,6 +28482,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "pako@npm:2.2.0"
+  checksum: 10c0/e5d31de1940fdd13cc4014296b0026112483d0834bce4856ca29c8af8438d030c6416986a0f6df7d5372cae18d6dd6c57f48b24a49d6c207c0a4cc66af15c07d
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -29641,6 +30044,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raf@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "raf@npm:3.4.1"
+  dependencies:
+    performance-now: "npm:^2.1.0"
+  checksum: 10c0/337f0853c9e6a77647b0f499beedafea5d6facfb9f2d488a624f88b03df2be72b8a0e7f9118a3ff811377d534912039a3311815700d2b6d2313f82f736f9eb6e
+  languageName: node
+  linkType: hard
+
 "railroad-diagrams@npm:^1.0.0":
   version: 1.0.0
   resolution: "railroad-diagrams@npm:1.0.0"
@@ -30755,6 +31167,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.13.7":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 10c0/12b069dc774001fbb0014f6a28f11c09ebfe3c0d984d88c9bced77fdb6fedbacbca434d24da9ae9371bfbf23f754869307fb51a4c98a8b8b18e5ef748677ca24
+  languageName: node
+  linkType: hard
+
 "regexp.prototype.flags@npm:^1.5.1, regexp.prototype.flags@npm:^1.5.3, regexp.prototype.flags@npm:^1.5.4":
   version: 1.5.4
   resolution: "regexp.prototype.flags@npm:1.5.4"
@@ -31106,6 +31525,13 @@ __metadata:
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10c0/4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
+  languageName: node
+  linkType: hard
+
+"rgbcolor@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "rgbcolor@npm:1.0.1"
+  checksum: 10c0/13af06c523351bac2854b85a22d1dfafd9310efd898e9bd96c8706f9aa09a3ddc8392ab00ae03d12950782164a97677f21834ffd84ffebf76ae106add319f956
   languageName: node
   linkType: hard
 
@@ -32294,6 +32720,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackblur-canvas@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "stackblur-canvas@npm:2.7.0"
+  checksum: 10c0/df290d0629056d5bb43d37548d0b24cb8593c79d742650e68489abf61013db578c9980724c2508bb738d107204f2e2494ab94c3cf69d6b725caa9c63b8c7e272
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -32872,6 +33305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"svg-pathdata@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "svg-pathdata@npm:6.0.3"
+  checksum: 10c0/1ba4ad2fa81e86df37d6e78d3be9e664bbedf97773b725a863a85db384285be32dc37d9c0d61e477d89594ee95b967d2c53d6bee2d76420aab670ab4124a38b9
+  languageName: node
+  linkType: hard
+
 "svgo@npm:^2.7.0":
   version: 2.8.0
   resolution: "svgo@npm:2.8.0"
@@ -33285,6 +33725,15 @@ __metadata:
   version: 1.0.0
   resolution: "text-hex@npm:1.0.0"
   checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10c0/8b9ae8524e3a332371060d0ca62f10ad49a13e954719ea689a6c3a8b8c15c8a56365ede2bb91c322fb0d44b6533785f0da603e066b7554d052999967fb72d600
   languageName: node
   linkType: hard
 
@@ -34509,6 +34958,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
+  languageName: node
+  linkType: hard
+
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: "npm:^1.0.2"
+  checksum: 10c0/eaffe645bd81a39e4bc3abb23df5895e9961dbdd49748ef3b173529e8b06ce9dd1163e9705d5309a1c61ee41ffcb825e2043bc0fd1659845ffbdf4b1515dfdb4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Adds `@globallogicuki/backstage-plugin-tech-insights-overview`: a catalog-wide overview for [Tech Insights](https://github.com/backstage/community-plugins/tree/main/workspaces/tech-insights) — one page aggregating check results across every component in the catalog. Ported from an internal plugin and decoupled for open source.

- **Fully passing** stat beside the check tiles, with a coverage caption when components are awaiting their first check results (never counted as passing).
- **Check tiles**, worst first, with severity-colored meters (red at ≥25% catalog failure) — each tile doubles as a page-wide filter.
- **Failures table**, worst first, filterable by name, owner, and check, with failing-check chips per row.
- **Failing-by-owner bars** — the accountability axis the per-check view lacks, keyed by canonical owner ref so a group and a user sharing a display name are never merged.

## Design for OSS

- **No hardcoded checks**: check IDs and names are discovered dynamically from `techInsightsApi.runBulkChecks`, so the page works against whatever checks the host's tech-insights backend has configured. The plugin itself needs zero configuration.
- **No internal provenance model**: the source plugin scoped scoring by an internal ownership annotation; that's removed — every component is scored on the checks that return results for it.
- **Default theme throughout**: standard MUI components; severity colors come from `theme.palette.warning/error`.
- Rows link to the component's catalog page (the one destination every instance has) rather than assuming an entity tech-insights tab.
- New-frontend-system alpha entry point (`PageBlueprint` at `/tech-insights-overview` with nav title/icon); classic-system usage documented in the README.

## Example app

The demo app gains a working tech-insights setup so the page can be exercised out of the box: `@backstage-community/plugin-tech-insights-backend` + the json-rules-engine checker in `packages/backend`, the community frontend plugin (which provides `techInsightsApiRef`), and three demo checks (has owner / description / tags) driven by the built-in metadata and ownership fact retrievers in `app-config.yaml`.

## Testing

- 15 unit tests: the pure aggregation (sorting, per-check/per-owner tallies, unscored handling, owner-ref edge cases), links, the page (render, filters, tile scoping, empty and error states), and the alpha extension.
- Verified live in the dev app against the real tech-insights backend — summary, tiles, table, and owner bars all populated from the demo checks.

Changeset included (minor, initial release).

https://claude.ai/code/session_011S94HUt1dZAqDM2mMbes97