### PR TITLE
feat(skills-marketplace): support multiple marketplaces and README docs

### DIFF
--- a/.changeset/multi-marketplace-support.md
+++ b/.changeset/multi-marketplace-support.md
@@ -1,0 +1,25 @@
+---
+'@globallogicuki/backstage-plugin-skills-marketplace': minor
+'@globallogicuki/backstage-plugin-skills-marketplace-backend': minor
+---
+
+Support pulling skills from multiple marketplace repos.
+
+`skillsMarketplace` now accepts an optional `marketplaces` list alongside (or
+instead of) the single `url`; each entry takes a repo tree `url` and may
+override `installUrlFormat`. Skills from every configured repo are listed
+together, tagged with their source repo, and filterable by repo name — the repo
+name is searchable too. Each skill's install commands use its own repo's git URL
+and marketplace name. A marketplace that fails to load no longer breaks the
+page: the others still render and the failure is reported as a warning.
+
+Repo names must be unique across all configured marketplaces.
+
+Skill docs now fall back to `README.md` when a plugin has no `SKILL.md`, so
+plugins documented with only a README render docs in the detail drawer instead
+of an empty state.
+
+**Breaking (API):** `GET /marketplace` now returns
+`{ marketplaces: [{ repo, url, installUrl, marketplace }], errors }` instead of
+`{ marketplace, installUrl }`, and `GET /skill-doc` accepts an optional `repo`
+query parameter. The frontend and backend plugins must be upgraded together.

--- a/app-config.local.tpl.yaml
+++ b/app-config.local.tpl.yaml
@@ -26,6 +26,11 @@ skillsMarketplace:
   url: MARKETPLACE_TREE_URL
   # URL format for the /plugin marketplace add install command shown to users.
   # installUrlFormat: https # ssh (default) | https
+  # Optional: pull skills in from more repos too. Skills from every marketplace
+  # are listed together and filterable by repo name, which must be unique.
+  # marketplaces:
+  #   - url: OTHER_MARKETPLACE_TREE_URL
+  #     installUrlFormat: ssh # optional per-entry override
 
 unleash:
   url: UNLEASH_URL

--- a/plugins/skills-marketplace-backend/README.md
+++ b/plugins/skills-marketplace-backend/README.md
@@ -9,10 +9,14 @@ cached for five minutes.
 
 ## Endpoints
 
-- `GET /api/skills-marketplace/marketplace` — the marketplace manifest plus
-  the derived git install URL.
-- `GET /api/skills-marketplace/skill-doc?source=./skills/foo` — the raw
-  `SKILL.md` for one skill (404 when the skill has none).
+- `GET /api/skills-marketplace/marketplace` — every configured marketplace as
+  `{ marketplaces: [{ repo, url, installUrl, marketplace }], errors: [] }`.
+  Marketplaces that fail to load are reported in `errors` so the rest still
+  render; the request only fails when none could be read.
+- `GET /api/skills-marketplace/skill-doc?source=./skills/foo&repo=my-repo` —
+  the raw docs for one skill: its `SKILL.md`, falling back to its `README.md`
+  (404 when it has neither). `repo` names the marketplace to read from and
+  defaults to the first configured one.
 
 ## Installation
 
@@ -33,7 +37,14 @@ backend.add(
 skillsMarketplace:
   url: https://github.com/my-org/skills-marketplace/tree/main
   installUrlFormat: https # optional: ssh (default) | https
+  # optional: pull skills in from more repos as well
+  marketplaces:
+    - url: https://gitlab.com/my-group/team-skills/-/tree/main
+      installUrlFormat: ssh # optional per-entry override
 ```
+
+Repo names must be unique across `url` and `marketplaces` — the repo name
+identifies a marketplace in the API and in the UI filter.
 
 See the frontend plugin's README for the full reference, including private
 repos.

--- a/plugins/skills-marketplace-backend/config.d.ts
+++ b/plugins/skills-marketplace-backend/config.d.ts
@@ -1,7 +1,8 @@
 export interface Config {
   /**
    * Configuration for the Skills Marketplace plugin. Required for the plugin
-   * to load skills — there are no built-in defaults.
+   * to load skills — there are no built-in defaults. Set `url`, or
+   * `marketplaces`, or both.
    */
   skillsMarketplace?: {
     /**
@@ -13,12 +14,24 @@ export interface Config {
      * Private repos are read with the credentials configured under
      * `integrations.*`.
      */
-    url: string;
+    url?: string;
     /**
      * URL format for the `/plugin marketplace add` install command shown to
      * users: `ssh` (`git@host:owner/repo.git`, the default) or `https`
-     * (`https://host/owner/repo.git`).
+     * (`https://host/owner/repo.git`). Applies to `url` and to any
+     * `marketplaces` entry that does not set its own.
      */
     installUrlFormat?: 'ssh' | 'https';
+    /**
+     * Additional marketplace repos to load skills from. Skills from every
+     * marketplace are shown together, filterable by repo name. Repo names
+     * must be unique across `url` and this list.
+     */
+    marketplaces?: Array<{
+      /** Web URL of the repo tree at the branch to read, as for `url`. */
+      url: string;
+      /** Overrides the top-level `installUrlFormat` for this repo. */
+      installUrlFormat?: 'ssh' | 'https';
+    }>;
   };
 }

--- a/plugins/skills-marketplace-backend/src/lib/config.test.ts
+++ b/plugins/skills-marketplace-backend/src/lib/config.test.ts
@@ -1,0 +1,85 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { readMarketplaceConfigs } from './config';
+
+const GITHUB = 'https://github.com/my-org/skills-marketplace/tree/main';
+const GITLAB = 'https://gitlab.com/my-group/team-skills/-/tree/main';
+
+const read = (data: object) =>
+  readMarketplaceConfigs(mockServices.rootConfig({ data }));
+
+describe('readMarketplaceConfigs', () => {
+  it('reads a single url', () => {
+    expect(read({ skillsMarketplace: { url: GITHUB } })).toEqual([
+      { repo: 'skills-marketplace', url: GITHUB, installUrlFormat: 'ssh' },
+    ]);
+  });
+
+  it('reads a marketplaces list on its own', () => {
+    expect(
+      read({
+        skillsMarketplace: { marketplaces: [{ url: GITHUB }, { url: GITLAB }] },
+      }),
+    ).toEqual([
+      { repo: 'skills-marketplace', url: GITHUB, installUrlFormat: 'ssh' },
+      { repo: 'team-skills', url: GITLAB, installUrlFormat: 'ssh' },
+    ]);
+  });
+
+  it('puts the single url first, then the list', () => {
+    const marketplaces = read({
+      skillsMarketplace: { url: GITHUB, marketplaces: [{ url: GITLAB }] },
+    });
+
+    expect(marketplaces.map(m => m.repo)).toEqual([
+      'skills-marketplace',
+      'team-skills',
+    ]);
+  });
+
+  it('inherits the top-level installUrlFormat, per-entry overrides win', () => {
+    const marketplaces = read({
+      skillsMarketplace: {
+        url: GITHUB,
+        installUrlFormat: 'https',
+        marketplaces: [{ url: GITLAB, installUrlFormat: 'ssh' }],
+      },
+    });
+
+    expect(marketplaces.map(m => m.installUrlFormat)).toEqual(['https', 'ssh']);
+  });
+
+  it('throws when nothing is configured', () => {
+    expect(() => read({})).toThrow(/not configured/);
+    expect(() => read({ skillsMarketplace: { marketplaces: [] } })).toThrow(
+      /not configured/,
+    );
+  });
+
+  it('throws on an unsupported installUrlFormat', () => {
+    expect(() =>
+      read({ skillsMarketplace: { url: GITHUB, installUrlFormat: 'ftp' } }),
+    ).toThrow(/invalid installUrlFormat/);
+    expect(() =>
+      read({
+        skillsMarketplace: {
+          marketplaces: [{ url: GITHUB, installUrlFormat: 'ftp' }],
+        },
+      }),
+    ).toThrow(/invalid installUrlFormat/);
+  });
+
+  it('throws when two marketplaces share a repo name', () => {
+    expect(() =>
+      read({
+        skillsMarketplace: {
+          url: GITHUB,
+          marketplaces: [
+            {
+              url: 'https://gitlab.com/other-group/skills-marketplace/-/tree/main',
+            },
+          ],
+        },
+      }),
+    ).toThrow(/named 'skills-marketplace'/);
+  });
+});

--- a/plugins/skills-marketplace-backend/src/lib/config.ts
+++ b/plugins/skills-marketplace-backend/src/lib/config.ts
@@ -1,0 +1,95 @@
+import { RootConfigService } from '@backstage/backend-plugin-api';
+import { InstallUrlFormat, deriveRepoName } from './repo';
+
+/** One resolved marketplace repo to read skills from. */
+export type MarketplaceConfig = {
+  /** Repo name, e.g. `skills-marketplace` — the id used to filter skills. */
+  repo: string;
+  /** Web URL of the repo tree at the branch to read. */
+  url: string;
+  installUrlFormat: InstallUrlFormat;
+};
+
+const NOT_CONFIGURED =
+  'Skills Marketplace is not configured: set skillsMarketplace.url (or a ' +
+  'skillsMarketplace.marketplaces list) in app-config.yaml to the web URL of ' +
+  'the repo tree that hosts your Claude Code marketplace, e.g. ' +
+  'https://github.com/my-org/skills-marketplace/tree/main';
+
+const readInstallUrlFormat = (
+  raw: string | undefined,
+  fallback: InstallUrlFormat,
+): InstallUrlFormat => {
+  if (raw === undefined) {
+    return fallback;
+  }
+  if (raw !== 'ssh' && raw !== 'https') {
+    throw new Error(
+      `Skills Marketplace: invalid installUrlFormat '${raw}'. ` +
+        `Supported values: ssh, https.`,
+    );
+  }
+  return raw;
+};
+
+const toMarketplace = (
+  url: string,
+  installUrlFormat: InstallUrlFormat,
+): MarketplaceConfig => ({
+  repo: deriveRepoName(url),
+  url,
+  installUrlFormat,
+});
+
+/**
+ * Resolve the configured marketplaces: the single `skillsMarketplace.url` and
+ * every entry of the optional `skillsMarketplace.marketplaces` list, in that
+ * order. Each entry inherits the top-level `installUrlFormat` unless it sets
+ * its own.
+ */
+export function readMarketplaceConfigs(
+  config: RootConfigService,
+): MarketplaceConfig[] {
+  const defaultFormat = readInstallUrlFormat(
+    config.getOptionalString('skillsMarketplace.installUrlFormat'),
+    'ssh',
+  );
+
+  const marketplaces: MarketplaceConfig[] = [];
+  const url = config.getOptionalString('skillsMarketplace.url');
+  if (url) {
+    marketplaces.push(toMarketplace(url, defaultFormat));
+  }
+  const entries =
+    config.getOptionalConfigArray('skillsMarketplace.marketplaces') ?? [];
+  for (const entry of entries) {
+    marketplaces.push(
+      toMarketplace(
+        entry.getString('url'),
+        readInstallUrlFormat(
+          entry.getOptionalString('installUrlFormat'),
+          defaultFormat,
+        ),
+      ),
+    );
+  }
+
+  if (marketplaces.length === 0) {
+    throw new Error(NOT_CONFIGURED);
+  }
+
+  // The repo name identifies a marketplace in the API and the UI filter, so
+  // two repos with the same name would be indistinguishable.
+  const duplicate = marketplaces.find(
+    (m, index) =>
+      marketplaces.findIndex(other => other.repo === m.repo) < index,
+  );
+  if (duplicate) {
+    throw new Error(
+      `Skills Marketplace: more than one configured marketplace is named ` +
+        `'${duplicate.repo}'. Repo names must be unique.`,
+    );
+  }
+
+  return marketplaces;
+}

--- a/plugins/skills-marketplace-backend/src/lib/repo.test.ts
+++ b/plugins/skills-marketplace-backend/src/lib/repo.test.ts
@@ -1,4 +1,4 @@
-import { deriveInstallUrl } from './repo';
+import { deriveInstallUrl, deriveRepoName } from './repo';
 
 describe('deriveInstallUrl', () => {
   it.each([
@@ -37,6 +37,29 @@ describe('deriveInstallUrl', () => {
 
   it('throws when the URL has no repo path', () => {
     expect(() => deriveInstallUrl('https://github.com/only-org')).toThrow(
+      /Cannot derive a repo path/,
+    );
+  });
+});
+
+describe('deriveRepoName', () => {
+  it.each([
+    [
+      'https://github.com/my-org/skills-marketplace/tree/main',
+      'skills-marketplace',
+    ],
+    [
+      'https://gitlab.com/my-group/sub-group/team-skills/-/tree/main',
+      'team-skills',
+    ],
+    ['https://bitbucket.org/my-workspace/skills/src/main', 'skills'],
+    ['https://github.com/my-org/skills-marketplace', 'skills-marketplace'],
+  ])('derives the repo name from %s', (treeUrl, expected) => {
+    expect(deriveRepoName(treeUrl)).toBe(expected);
+  });
+
+  it('throws when the URL has no repo path', () => {
+    expect(() => deriveRepoName('https://github.com/only-org')).toThrow(
       /Cannot derive a repo path/,
     );
   });

--- a/plugins/skills-marketplace-backend/src/lib/repo.ts
+++ b/plugins/skills-marketplace-backend/src/lib/repo.ts
@@ -18,6 +18,30 @@ const BRANCH_MARKER = /\/(?:-\/)?(?:tree|blob|src)\/.*$/;
 /** URL format for the marketplace install command. */
 export type InstallUrlFormat = 'ssh' | 'https';
 
+/** `owner/repo` (or `group/sub-group/repo`) from a repo web URL. */
+function repoPath(treeUrl: string): string {
+  const path = new URL(treeUrl).pathname
+    .replace(BRANCH_MARKER, '')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/, '');
+  if (!path || !path.includes('/')) {
+    throw new Error(
+      `Cannot derive a repo path from skillsMarketplace.url '${treeUrl}'`,
+    );
+  }
+  return path;
+}
+
+/**
+ * The repo name from a tree URL, e.g.
+ * `https://github.com/my-org/skills-marketplace/tree/main` →
+ * `skills-marketplace`. Used to label and filter skills by their source repo.
+ */
+export function deriveRepoName(treeUrl: string): string {
+  const segments = repoPath(treeUrl).split('/');
+  return segments[segments.length - 1];
+}
+
 /**
  * Derive the git URL for the install command from the configured tree URL,
  * e.g. `https://github.com/my-org/repo/tree/main` →
@@ -28,17 +52,9 @@ export function deriveInstallUrl(
   treeUrl: string,
   format: InstallUrlFormat = 'ssh',
 ): string {
-  const { host, pathname } = new URL(treeUrl);
-  const repoPath = pathname
-    .replace(BRANCH_MARKER, '')
-    .replace(/^\/+|\/+$/g, '')
-    .replace(/\.git$/, '');
-  if (!repoPath || !repoPath.includes('/')) {
-    throw new Error(
-      `Cannot derive a repo path from skillsMarketplace.url '${treeUrl}'`,
-    );
-  }
+  const { host } = new URL(treeUrl);
+  const path = repoPath(treeUrl);
   return format === 'https'
-    ? `https://${host}/${repoPath}.git`
-    : `git@${host}:${repoPath}.git`;
+    ? `https://${host}/${path}.git`
+    : `git@${host}:${path}.git`;
 }

--- a/plugins/skills-marketplace-backend/src/plugin.test.ts
+++ b/plugins/skills-marketplace-backend/src/plugin.test.ts
@@ -35,8 +35,15 @@ describe('skillsMarketplacePlugin', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      marketplace: manifest,
-      installUrl: 'git@github.com:my-org/skills-marketplace.git',
+      marketplaces: [
+        {
+          repo: 'skills-marketplace',
+          url: 'https://github.com/my-org/skills-marketplace/tree/main',
+          installUrl: 'git@github.com:my-org/skills-marketplace.git',
+          marketplace: manifest,
+        },
+      ],
+      errors: [],
     });
   });
 });

--- a/plugins/skills-marketplace-backend/src/service/router.test.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.test.ts
@@ -6,10 +6,16 @@ import { createRouter } from './router';
 
 const TREE_URL =
   'https://bitbucket.org/my-workspace/skills-marketplace/src/main';
+const OTHER_TREE_URL = 'https://github.com/my-org/team-skills/tree/main';
 
 const manifest = {
   name: 'my-marketplace',
   plugins: [{ name: 'foo', source: './skills/foo', description: 'Foo skill' }],
+};
+
+const otherManifest = {
+  name: 'team-marketplace',
+  plugins: [{ name: 'bar', source: './skills/bar', description: 'Bar skill' }],
 };
 
 describe('createRouter', () => {
@@ -39,6 +45,21 @@ describe('createRouter', () => {
     buffer: async () => Buffer.from(content, 'utf8'),
   });
 
+  /** Serve each tree URL its own content; anything else is a 404. */
+  const serve = (contentByTreeUrl: Record<string, string | Error>) =>
+    readUrl.mockImplementation(async (url: string) => {
+      const match = Object.entries(contentByTreeUrl).find(([treeUrl]) =>
+        url.startsWith(treeUrl),
+      );
+      if (!match) {
+        throw new NotFoundError(url);
+      }
+      if (match[1] instanceof Error) {
+        throw match[1];
+      }
+      return readUrlResponse(match[1]);
+    });
+
   beforeEach(async () => {
     readUrl.mockReset();
     app = await buildApp();
@@ -52,11 +73,87 @@ describe('createRouter', () => {
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({
-        marketplace: manifest,
-        installUrl: 'git@bitbucket.org:my-workspace/skills-marketplace.git',
+        marketplaces: [
+          {
+            repo: 'skills-marketplace',
+            url: TREE_URL,
+            installUrl: 'git@bitbucket.org:my-workspace/skills-marketplace.git',
+            marketplace: manifest,
+          },
+        ],
+        errors: [],
       });
       expect(readUrl).toHaveBeenCalledWith(
         `${TREE_URL}/.claude-plugin/marketplace.json`,
+      );
+    });
+
+    it('returns every configured marketplace', async () => {
+      app = await buildApp({
+        skillsMarketplace: {
+          url: TREE_URL,
+          marketplaces: [{ url: OTHER_TREE_URL, installUrlFormat: 'https' }],
+        },
+      });
+      serve({
+        [TREE_URL]: JSON.stringify(manifest),
+        [OTHER_TREE_URL]: JSON.stringify(otherManifest),
+      });
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(200);
+      expect(response.body.marketplaces).toEqual([
+        {
+          repo: 'skills-marketplace',
+          url: TREE_URL,
+          installUrl: 'git@bitbucket.org:my-workspace/skills-marketplace.git',
+          marketplace: manifest,
+        },
+        {
+          repo: 'team-skills',
+          url: OTHER_TREE_URL,
+          installUrl: 'https://github.com/my-org/team-skills.git',
+          marketplace: otherManifest,
+        },
+      ]);
+      expect(response.body.errors).toEqual([]);
+    });
+
+    it('reports a failed marketplace alongside the ones that loaded', async () => {
+      app = await buildApp({
+        skillsMarketplace: {
+          marketplaces: [{ url: TREE_URL }, { url: OTHER_TREE_URL }],
+        },
+      });
+      serve({ [TREE_URL]: JSON.stringify(manifest) });
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(200);
+      expect(response.body.marketplaces).toHaveLength(1);
+      expect(response.body.errors).toEqual([
+        {
+          repo: 'team-skills',
+          url: OTHER_TREE_URL,
+          message: expect.stringMatching(/No .*marketplace.json/),
+        },
+      ]);
+    });
+
+    it('returns 502 when no configured marketplace loads', async () => {
+      app = await buildApp({
+        skillsMarketplace: {
+          marketplaces: [{ url: TREE_URL }, { url: OTHER_TREE_URL }],
+        },
+      });
+      readUrl.mockRejectedValue(new NotFoundError('nope'));
+
+      const response = await request(app).get('/marketplace');
+
+      expect(response.status).toEqual(502);
+      expect(response.body.error.message).toMatch(
+        /No configured marketplace could be loaded/,
       );
     });
 
@@ -69,7 +166,7 @@ describe('createRouter', () => {
       const response = await request(app).get('/marketplace');
 
       expect(response.status).toEqual(200);
-      expect(response.body.installUrl).toEqual(
+      expect(response.body.marketplaces[0].installUrl).toEqual(
         'https://bitbucket.org/my-workspace/skills-marketplace.git',
       );
     });
@@ -138,7 +235,65 @@ describe('createRouter', () => {
       expect(readUrl).toHaveBeenCalledWith(`${TREE_URL}/skills/foo/SKILL.md`);
     });
 
-    it('returns 404 when the skill has no SKILL.md', async () => {
+    it('reads from the marketplace named by repo', async () => {
+      app = await buildApp({
+        skillsMarketplace: {
+          url: TREE_URL,
+          marketplaces: [{ url: OTHER_TREE_URL }],
+        },
+      });
+      readUrl.mockResolvedValue(readUrlResponse('Bar docs'));
+
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/bar', repo: 'team-skills' });
+
+      expect(response.status).toEqual(200);
+      expect(readUrl).toHaveBeenCalledWith(
+        `${OTHER_TREE_URL}/skills/bar/SKILL.md`,
+      );
+    });
+
+    it('returns 404 for an unknown repo', async () => {
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/foo', repo: 'nope' });
+
+      expect(response.status).toEqual(404);
+      expect(response.body.error.message).toMatch(/No configured marketplace/);
+      expect(readUrl).not.toHaveBeenCalled();
+    });
+
+    it('falls back to README.md when there is no SKILL.md', async () => {
+      readUrl.mockImplementation(async (url: string) => {
+        if (url.endsWith('/SKILL.md')) {
+          throw new NotFoundError(url);
+        }
+        return readUrlResponse('# Readme docs');
+      });
+
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/foo' });
+
+      expect(response.status).toEqual(200);
+      expect(response.text).toEqual('# Readme docs');
+      expect(readUrl).toHaveBeenCalledWith(`${TREE_URL}/skills/foo/README.md`);
+    });
+
+    it('prefers SKILL.md over README.md', async () => {
+      readUrl.mockResolvedValue(readUrlResponse('Skill docs'));
+
+      const response = await request(app)
+        .get('/skill-doc')
+        .query({ source: './skills/foo' });
+
+      expect(response.text).toEqual('Skill docs');
+      expect(readUrl).toHaveBeenCalledTimes(1);
+      expect(readUrl).toHaveBeenCalledWith(`${TREE_URL}/skills/foo/SKILL.md`);
+    });
+
+    it('returns 404 when the skill has neither doc file', async () => {
       readUrl.mockRejectedValue(new NotFoundError('nope'));
 
       const response = await request(app)
@@ -146,6 +301,9 @@ describe('createRouter', () => {
         .query({ source: './skills/foo' });
 
       expect(response.status).toEqual(404);
+      expect(response.body.error.message).toMatch(
+        /No SKILL.md or README.md found/,
+      );
     });
 
     it('rejects a missing or traversal source', async () => {

--- a/plugins/skills-marketplace-backend/src/service/router.ts
+++ b/plugins/skills-marketplace-backend/src/service/router.ts
@@ -8,11 +8,8 @@ import {
   RootConfigService,
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
-import {
-  InstallUrlFormat,
-  deriveInstallUrl,
-  resolveFileUrl,
-} from '../lib/repo';
+import { MarketplaceConfig, readMarketplaceConfigs } from '../lib/config';
+import { deriveInstallUrl, resolveFileUrl } from '../lib/repo';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -36,9 +33,21 @@ const isSafeSource = (source: string): boolean =>
     .split('/')
     .every(segment => segment !== '..' && segment !== '.');
 
+// Docs for a skill, in the order they are tried: plugins written as Claude Code
+// skills carry a SKILL.md, while plainer ones only have a README.
+const DOC_FILES = ['SKILL.md', 'README.md'];
+
 const isNotFound = (error: unknown): boolean =>
   error instanceof NotFoundError ||
   (error instanceof Error && error.name === 'NotFoundError');
+
+/** One marketplace that failed to load, reported alongside the ones that did. */
+type MarketplaceFailure = {
+  repo: string;
+  url: string;
+  message: string;
+  status: number;
+};
 
 export async function createRouter(
   options: RouterOptions,
@@ -58,94 +67,134 @@ export async function createRouter(
     return content;
   };
 
-  const getTreeUrl = (): string => {
-    const treeUrl = config.getOptionalString('skillsMarketplace.url');
-    if (!treeUrl) {
-      throw new Error(
-        'Skills Marketplace is not configured: set skillsMarketplace.url in ' +
-          'app-config.yaml to the web URL of the repo tree that hosts your ' +
-          'Claude Code marketplace, e.g. ' +
-          'https://github.com/my-org/skills-marketplace/tree/main',
+  const loadMarketplace = async (marketplace: MarketplaceConfig) => {
+    const { repo, url } = marketplace;
+    const fail = (message: string, status: number): MarketplaceFailure => ({
+      repo,
+      url,
+      message,
+      status,
+    });
+
+    let raw;
+    try {
+      raw = await readFile(url, '.claude-plugin/marketplace.json');
+    } catch (error) {
+      if (isNotFound(error)) {
+        return fail(`No .claude-plugin/marketplace.json found at ${url}.`, 404);
+      }
+      throw error;
+    }
+    let manifest;
+    try {
+      manifest = JSON.parse(raw);
+    } catch {
+      return fail(`Marketplace manifest at ${url} is not valid JSON.`, 502);
+    }
+    if (!Array.isArray(manifest.plugins)) {
+      return fail(
+        `Marketplace manifest at ${url} is missing a "plugins" array.`,
+        502,
       );
     }
-    return treeUrl;
+    return {
+      repo,
+      url,
+      installUrl: deriveInstallUrl(url, marketplace.installUrlFormat),
+      marketplace: manifest,
+    };
   };
 
-  const getInstallUrlFormat = (): InstallUrlFormat => {
-    const format =
-      config.getOptionalString('skillsMarketplace.installUrlFormat') ?? 'ssh';
-    if (format !== 'ssh' && format !== 'https') {
-      throw new Error(
-        `Skills Marketplace: invalid installUrlFormat '${format}'. ` +
-          `Supported values: ssh, https.`,
-      );
-    }
-    return format;
-  };
+  const isFailure = (
+    result: Awaited<ReturnType<typeof loadMarketplace>>,
+  ): result is MarketplaceFailure => 'status' in result;
 
   const router = Router();
   router.use(express.json());
 
   router.get('/marketplace', async (_req, res) => {
-    const treeUrl = getTreeUrl();
-    let raw;
-    try {
-      raw = await readFile(treeUrl, '.claude-plugin/marketplace.json');
-    } catch (error) {
-      if (isNotFound(error)) {
-        res.status(404).json({
-          error: {
-            message: `No .claude-plugin/marketplace.json found at ${treeUrl}.`,
-          },
-        });
-        return;
-      }
-      throw error;
+    const configured = readMarketplaceConfigs(config);
+    const results = await Promise.all(configured.map(loadMarketplace));
+    const failures = results.filter(isFailure);
+    const marketplaces = results.filter(result => !isFailure(result));
+
+    for (const failure of failures) {
+      logger.warn(
+        `Skills Marketplace: skipping '${failure.repo}' — ${failure.message}`,
+      );
     }
-    let marketplace;
-    try {
-      marketplace = JSON.parse(raw);
-    } catch {
-      res.status(502).json({
-        error: { message: 'Marketplace manifest is not valid JSON.' },
-      });
-      return;
-    }
-    if (!Array.isArray(marketplace.plugins)) {
-      res.status(502).json({
+
+    if (marketplaces.length === 0) {
+      // A single marketplace reports its own failure verbatim; with several,
+      // no one status fits, so report them together.
+      const [first] = failures;
+      res.status(failures.length === 1 ? first.status : 502).json({
         error: {
-          message: 'Marketplace manifest is missing a "plugins" array.',
+          message:
+            failures.length === 1
+              ? first.message
+              : `No configured marketplace could be loaded: ${failures
+                  .map(failure => failure.message)
+                  .join(' ')}`,
         },
       });
       return;
     }
+
     res.json({
-      marketplace,
-      installUrl: deriveInstallUrl(treeUrl, getInstallUrlFormat()),
+      marketplaces,
+      errors: failures.map(({ repo, url, message }) => ({
+        repo,
+        url,
+        message,
+      })),
     });
   });
 
   router.get('/skill-doc', async (req, res) => {
-    const source = req.query.source;
+    const { source, repo } = req.query;
     if (typeof source !== 'string' || !isSafeSource(source)) {
       res.status(400).json({
         error: { message: 'Invalid "source" query parameter.' },
       });
       return;
     }
-    const treeUrl = getTreeUrl();
-    try {
-      const content = await readFile(treeUrl, `${source}/SKILL.md`);
-      res.type('text/markdown').send(content);
-    } catch (error) {
-      if (isNotFound(error)) {
-        res.status(404).json({
-          error: { message: `No SKILL.md found for ${source}.` },
-        });
-        return;
-      }
-      throw error;
+    if (repo !== undefined && typeof repo !== 'string') {
+      res.status(400).json({
+        error: { message: 'Invalid "repo" query parameter.' },
+      });
+      return;
     }
+
+    const configured = readMarketplaceConfigs(config);
+    // Without a repo the first configured marketplace is the only sensible
+    // target — the common single-marketplace case.
+    const marketplace = repo
+      ? configured.find(candidate => candidate.repo === repo)
+      : configured[0];
+    if (!marketplace) {
+      res.status(404).json({
+        error: { message: `No configured marketplace named '${repo}'.` },
+      });
+      return;
+    }
+
+    for (const file of DOC_FILES) {
+      try {
+        const content = await readFile(marketplace.url, `${source}/${file}`);
+        res.type('text/markdown').send(content);
+        return;
+      } catch (error) {
+        if (!isNotFound(error)) {
+          throw error;
+        }
+      }
+    }
+    res.status(404).json({
+      error: {
+        message: `No ${DOC_FILES.join(' or ')} found for ${source}.`,
+      },
+    });
   });
 
   router.use(

--- a/plugins/skills-marketplace/README.md
+++ b/plugins/skills-marketplace/README.md
@@ -5,9 +5,12 @@ Browse and install shared **Claude Code skills** from a
 (a repo containing `.claude-plugin/marketplace.json`) inside Backstage.
 
 - Skill cards with name, description, category, and keywords; full-text search
-  and category filtering.
-- A detail drawer with the skill's rendered `SKILL.md` and copy-able Claude
-  Code install commands.
+  plus category and repo filtering.
+- One marketplace repo, or several — skills from every configured repo are
+  listed together and filterable by repo name.
+- A detail drawer with the skill's rendered docs — its `SKILL.md`, or its
+  `README.md` where it has no `SKILL.md` — and copy-able Claude Code install
+  commands.
 - The repo is read server-side by
   `@globallogicuki/backstage-plugin-skills-marketplace-backend` via Backstage's
   `UrlReader`, so GitHub, GitLab, and Bitbucket all work — public or private,
@@ -86,6 +89,34 @@ https://bitbucket.org/my-workspace/skills-marketplace/src/main
 
 `installUrlFormat` sets the git URL shown in the `/plugin marketplace add`
 command: `git@host:owner/repo.git` (ssh) or `https://host/owner/repo.git`.
+
+### Multiple marketplaces
+
+Add a `marketplaces` list to pull skills in from more than one repo. Each entry
+takes the same `url`, and may override `installUrlFormat`; hosts can be mixed
+freely:
+
+```yaml
+skillsMarketplace:
+  installUrlFormat: https
+  marketplaces:
+    - url: https://github.com/my-org/skills-marketplace/tree/main
+    - url: https://gitlab.com/my-group/team-skills/-/tree/main
+      installUrlFormat: ssh
+    - url: https://bitbucket.org/my-workspace/platform-skills/src/main
+```
+
+`url` and `marketplaces` can be used together — the single `url` is simply
+listed first. Every skill is shown with the repo it came from, and a **Repo**
+filter appears once more than one marketplace is configured; the repo name is
+searchable too. Each skill's install commands use its own repo's git URL and
+marketplace name, so installing from a mixed listing always points at the right
+place.
+
+Repo names must be unique across all configured marketplaces — two repos with
+the same name (in different orgs, say) cannot be told apart in the UI, and the
+plugin reports a config error rather than guessing. If one marketplace fails to
+load, the page still lists the others and warns about the one it skipped.
 
 ### Private repos
 

--- a/plugins/skills-marketplace/src/SkillCard.test.tsx
+++ b/plugins/skills-marketplace/src/SkillCard.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { SkillCard } from './SkillCard';
-import { Skill } from './api';
+import { Skill, SkillListing } from './api';
 
 const skill: Skill = {
   name: 'deck-gl',
@@ -11,9 +11,16 @@ const skill: Skill = {
   keywords: ['pptx', 'slides', 'deck', 'template', 'brand', 'extra'],
 };
 
+const listing: SkillListing = {
+  skill,
+  repo: 'skills-marketplace',
+  marketplaceName: 'my-marketplace',
+  installUrl: 'git@github.com:my-org/skills-marketplace.git',
+};
+
 describe('SkillCard', () => {
   it('renders name, description, category and at most five keywords', async () => {
-    await renderInTestApp(<SkillCard skill={skill} onSelect={jest.fn()} />);
+    await renderInTestApp(<SkillCard listing={listing} onSelect={jest.fn()} />);
 
     expect(screen.getByText('deck-gl')).toBeInTheDocument();
     expect(screen.getByText('Build PowerPoint decks')).toBeInTheDocument();
@@ -26,7 +33,10 @@ describe('SkillCard', () => {
   it('omits category and keyword chips when absent', async () => {
     await renderInTestApp(
       <SkillCard
-        skill={{ name: 'plain', source: './plain', description: 'No tags' }}
+        listing={{
+          ...listing,
+          skill: { name: 'plain', source: './plain', description: 'No tags' },
+        }}
         onSelect={jest.fn()}
       />,
     );
@@ -35,12 +45,27 @@ describe('SkillCard', () => {
     expect(screen.queryByText('presentations')).toBeNull();
   });
 
-  it('calls onSelect with the skill when clicked', async () => {
+  it('shows the source repo only when asked', async () => {
+    const { unmount } = await renderInTestApp(
+      <SkillCard listing={listing} onSelect={jest.fn()} />,
+    );
+
+    expect(screen.queryByText('skills-marketplace')).toBeNull();
+    unmount();
+
+    await renderInTestApp(
+      <SkillCard listing={listing} showRepo onSelect={jest.fn()} />,
+    );
+
+    expect(screen.getByText('skills-marketplace')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with the listing when clicked', async () => {
     const onSelect = jest.fn();
-    await renderInTestApp(<SkillCard skill={skill} onSelect={onSelect} />);
+    await renderInTestApp(<SkillCard listing={listing} onSelect={onSelect} />);
 
     screen.getByTestId('skill-card-deck-gl').click();
 
-    expect(onSelect).toHaveBeenCalledWith(skill);
+    expect(onSelect).toHaveBeenCalledWith(listing);
   });
 });

--- a/plugins/skills-marketplace/src/SkillCard.tsx
+++ b/plugins/skills-marketplace/src/SkillCard.tsx
@@ -3,25 +3,29 @@ import CardActionArea from '@material-ui/core/CardActionArea';
 import CardContent from '@material-ui/core/CardContent';
 import Chip from '@material-ui/core/Chip';
 import Typography from '@material-ui/core/Typography';
-import { Skill } from './api';
+import { SkillListing } from './api';
 import { useSkillsStyles } from './styles';
 
 /** One skill as a card; clicking it opens the detail drawer. */
 export const SkillCard = ({
-  skill,
+  listing,
+  showRepo,
   onSelect,
 }: {
-  skill: Skill;
-  onSelect: (skill: Skill) => void;
+  listing: SkillListing;
+  /** Show the source repo — only useful with more than one marketplace. */
+  showRepo?: boolean;
+  onSelect: (listing: SkillListing) => void;
 }) => {
   const classes = useSkillsStyles();
+  const { skill } = listing;
   const keywords = skill.keywords ?? [];
 
   return (
     <Card className={classes.card}>
       <CardActionArea
         className={classes.cardActionArea}
-        onClick={() => onSelect(skill)}
+        onClick={() => onSelect(listing)}
         data-testid={`skill-card-${skill.name}`}
       >
         <CardContent className={classes.cardContent}>
@@ -47,6 +51,16 @@ export const SkillCard = ({
                 <Chip key={kw} label={kw} size="small" />
               ))}
             </div>
+          )}
+          {showRepo && (
+            <Typography
+              variant="caption"
+              color="textSecondary"
+              component="div"
+              className={classes.cardRepo}
+            >
+              {listing.repo}
+            </Typography>
           )}
         </CardContent>
       </CardActionArea>

--- a/plugins/skills-marketplace/src/SkillDetailDrawer.test.tsx
+++ b/plugins/skills-marketplace/src/SkillDetailDrawer.test.tsx
@@ -1,7 +1,12 @@
 import { screen, waitFor } from '@testing-library/react';
 import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
 import { SkillDetailDrawer } from './SkillDetailDrawer';
-import { Skill, SkillsMarketplaceApi, skillsMarketplaceApiRef } from './api';
+import {
+  Skill,
+  SkillListing,
+  SkillsMarketplaceApi,
+  skillsMarketplaceApiRef,
+} from './api';
 
 const skill: Skill = {
   name: 'deck-gl',
@@ -11,17 +16,27 @@ const skill: Skill = {
   keywords: ['pptx', 'slides'],
 };
 
+const listing: SkillListing = {
+  skill,
+  repo: 'my-repo',
+  marketplaceName: 'my-marketplace',
+  installUrl: 'git@github.com:my-org/my-repo.git',
+};
+
 describe('SkillDetailDrawer', () => {
   const getSkillDoc = jest.fn();
   const mockApi = { getSkillDoc } as unknown as SkillsMarketplaceApi;
 
-  const render = (selected: Skill | null, onClose = jest.fn()) =>
+  const render = (
+    selected: SkillListing | null,
+    onClose = jest.fn(),
+    showRepo = false,
+  ) =>
     renderInTestApp(
       <TestApiProvider apis={[[skillsMarketplaceApiRef, mockApi]]}>
         <SkillDetailDrawer
-          skill={selected}
-          marketplaceName="my-marketplace"
-          installUrl="git@github.com:my-org/my-repo.git"
+          listing={selected}
+          showRepo={showRepo}
           onClose={onClose}
         />
       </TestApiProvider>,
@@ -43,7 +58,7 @@ describe('SkillDetailDrawer', () => {
       body: 'Doc body text',
     });
 
-    await render(skill);
+    await render(listing);
 
     expect(screen.getByText('deck-gl')).toBeInTheDocument();
     expect(screen.getByText('Build PowerPoint decks')).toBeInTheDocument();
@@ -59,17 +74,17 @@ describe('SkillDetailDrawer', () => {
     await waitFor(() => {
       expect(screen.getByText('Doc body text')).toBeInTheDocument();
     });
-    expect(getSkillDoc).toHaveBeenCalledWith('./skills/deck-gl');
+    expect(getSkillDoc).toHaveBeenCalledWith('./skills/deck-gl', 'my-repo');
   });
 
-  it('shows an empty state when the skill has no SKILL.md', async () => {
+  it('shows an empty state when the skill has no docs', async () => {
     getSkillDoc.mockResolvedValue(undefined);
 
-    await render(skill);
+    await render(listing);
 
     await waitFor(() => {
       expect(
-        screen.getByText(/does not provide SKILL.md documentation/),
+        screen.getByText(/does not provide a SKILL.md or README.md/),
       ).toBeInTheDocument();
     });
   });
@@ -77,18 +92,26 @@ describe('SkillDetailDrawer', () => {
   it('shows an error panel when the documentation fails to load', async () => {
     getSkillDoc.mockRejectedValue(new Error('boom'));
 
-    await render(skill);
+    await render(listing);
 
     await waitFor(() => {
       expect(screen.getAllByText(/boom/).length).toBeGreaterThan(0);
     });
   });
 
+  it('shows the source repo when asked', async () => {
+    getSkillDoc.mockResolvedValue(undefined);
+
+    await render(listing, jest.fn(), true);
+
+    expect(screen.getByText('my-repo')).toBeInTheDocument();
+  });
+
   it('calls onClose when the close button is clicked', async () => {
     getSkillDoc.mockResolvedValue(undefined);
     const onClose = jest.fn();
 
-    await render(skill, onClose);
+    await render(listing, onClose);
 
     screen.getByLabelText('Close').click();
 

--- a/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
+++ b/plugins/skills-marketplace/src/SkillDetailDrawer.tsx
@@ -12,7 +12,7 @@ import {
   CopyTextButton,
   ResponseErrorPanel,
 } from '@backstage/core-components';
-import { Skill, skillsMarketplaceApiRef } from './api';
+import { SkillListing, skillsMarketplaceApiRef } from './api';
 import { useSkillsStyles } from './styles';
 
 const InstallCommand = ({ command }: { command: string }) => {
@@ -25,27 +25,29 @@ const InstallCommand = ({ command }: { command: string }) => {
   );
 };
 
-/** Skill detail drawer: metadata, install commands, and SKILL.md docs. */
+/** Skill detail drawer: metadata, install commands, and the skill's docs. */
 export const SkillDetailDrawer = ({
-  skill,
-  marketplaceName,
-  installUrl,
+  listing,
+  showRepo,
   onClose,
 }: {
-  skill: Skill | null;
-  marketplaceName: string;
-  installUrl: string;
+  listing: SkillListing | null;
+  /** Show the source repo — only useful with more than one marketplace. */
+  showRepo?: boolean;
   onClose: () => void;
 }) => {
   const classes = useSkillsStyles();
   const skillsMarketplaceApi = useApi(skillsMarketplaceApiRef);
 
-  const { value, loading, error } = useAsync(async () => {
-    if (!skill) return undefined;
-    return skillsMarketplaceApi.getSkillDoc(skill.source);
-  }, [skill?.source]);
+  const skill = listing?.skill;
 
-  const addCommand = `/plugin marketplace add ${installUrl}`;
+  const { value, loading, error } = useAsync(async () => {
+    if (!listing) return undefined;
+    return skillsMarketplaceApi.getSkillDoc(listing.skill.source, listing.repo);
+  }, [listing?.repo, listing?.skill.source]);
+
+  const marketplaceName = listing?.marketplaceName ?? '';
+  const addCommand = `/plugin marketplace add ${listing?.installUrl ?? ''}`;
   const installCommand = skill
     ? `/plugin install ${skill.name}@${marketplaceName}`
     : '';
@@ -53,11 +55,11 @@ export const SkillDetailDrawer = ({
   return (
     <Drawer
       anchor="right"
-      open={Boolean(skill)}
+      open={Boolean(listing)}
       onClose={onClose}
       classes={{ paper: classes.drawerPaper }}
     >
-      {skill && (
+      {listing && skill && (
         <>
           <div className={classes.drawerHeader}>
             <div className={classes.drawerTitleBlock}>
@@ -72,6 +74,14 @@ export const SkillDetailDrawer = ({
                 {skill.description}
               </Typography>
               <div className={classes.drawerMeta}>
+                {showRepo && (
+                  <Chip
+                    label={listing.repo}
+                    size="small"
+                    variant="outlined"
+                    color="primary"
+                  />
+                )}
                 {skill.category && (
                   <Chip
                     label={skill.category}
@@ -119,7 +129,7 @@ export const SkillDetailDrawer = ({
             {error && <ResponseErrorPanel error={error} />}
             {!loading && !error && !value && (
               <Typography variant="body2" color="textSecondary">
-                This skill does not provide SKILL.md documentation.
+                This skill does not provide a SKILL.md or README.md.
               </Typography>
             )}
             {value && <MarkdownContent content={value.body} dialect="gfm" />}

--- a/plugins/skills-marketplace/src/SkillsMarketplacePage.test.tsx
+++ b/plugins/skills-marketplace/src/SkillsMarketplacePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
 import { SkillsMarketplacePage } from './SkillsMarketplacePage';
 import {
@@ -8,26 +8,55 @@ import {
 } from './api';
 
 const response: MarketplaceResponse = {
-  marketplace: {
-    name: 'my-marketplace',
-    plugins: [
-      {
-        name: 'deck-gl',
-        source: './skills/deck-gl',
-        description: 'Build PowerPoint decks',
-        category: 'presentations',
-        keywords: ['pptx'],
+  marketplaces: [
+    {
+      repo: 'my-repo',
+      url: 'https://github.com/my-org/my-repo/tree/main',
+      installUrl: 'git@github.com:my-org/my-repo.git',
+      marketplace: {
+        name: 'my-marketplace',
+        plugins: [
+          {
+            name: 'deck-gl',
+            source: './skills/deck-gl',
+            description: 'Build PowerPoint decks',
+            category: 'presentations',
+            keywords: ['pptx'],
+          },
+          {
+            name: 'jira-workflow',
+            source: './skills/jira-workflow',
+            description: 'Work Jira tickets',
+            category: 'workflow',
+            keywords: ['jira'],
+          },
+        ],
       },
-      {
-        name: 'jira-workflow',
-        source: './skills/jira-workflow',
-        description: 'Work Jira tickets',
-        category: 'workflow',
-        keywords: ['jira'],
+    },
+  ],
+};
+
+/** The same skills, plus a second marketplace repo. */
+const multiResponse: MarketplaceResponse = {
+  marketplaces: [
+    ...response.marketplaces,
+    {
+      repo: 'team-skills',
+      url: 'https://gitlab.com/my-group/team-skills/-/tree/main',
+      installUrl: 'git@gitlab.com:my-group/team-skills.git',
+      marketplace: {
+        name: 'team-marketplace',
+        plugins: [
+          {
+            name: 'release-notes',
+            source: './skills/release-notes',
+            description: 'Draft release notes',
+            category: 'workflow',
+          },
+        ],
       },
-    ],
-  },
-  installUrl: 'git@github.com:my-org/my-repo.git',
+    },
+  ],
 };
 
 describe('SkillsMarketplacePage', () => {
@@ -44,6 +73,12 @@ describe('SkillsMarketplacePage', () => {
         <SkillsMarketplacePage />
       </TestApiProvider>,
     );
+
+  /** Pick a value from the repo filter select. */
+  const selectRepo = (name: string) => {
+    fireEvent.mouseDown(screen.getByLabelText('Filter by repo'));
+    fireEvent.click(within(screen.getByRole('listbox')).getByText(name));
+  };
 
   beforeEach(() => {
     getMarketplace.mockReset();
@@ -153,5 +188,136 @@ describe('SkillsMarketplacePage', () => {
     expect(
       screen.getByText('/plugin install deck-gl@my-marketplace'),
     ).toBeInTheDocument();
+  });
+
+  it('hides the repo filter with a single marketplace', async () => {
+    getMarketplace.mockResolvedValue(response);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText('Filter by repo')).toBeNull();
+  });
+
+  it('lists skills from every marketplace', async () => {
+    getMarketplace.mockResolvedValue(multiResponse);
+
+    await render();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('skill-card-release-notes')).toBeInTheDocument();
+    expect(screen.getByText('3 of 3')).toBeInTheDocument();
+    // Each card is labelled with its source repo.
+    expect(screen.getByText('team-skills')).toBeInTheDocument();
+  });
+
+  it('filters skills by repo', async () => {
+    getMarketplace.mockResolvedValue(multiResponse);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    selectRepo('team-skills');
+
+    expect(screen.getByTestId('skill-card-release-notes')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-card-deck-gl')).toBeNull();
+    expect(screen.getByText('1 of 3')).toBeInTheDocument();
+
+    selectRepo('All repos');
+
+    expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    expect(screen.getByText('3 of 3')).toBeInTheDocument();
+  });
+
+  it('combines the repo filter with the search query', async () => {
+    getMarketplace.mockResolvedValue(multiResponse);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    selectRepo('my-repo');
+    fireEvent.change(screen.getByPlaceholderText(/Search skills/), {
+      target: { value: 'jira' },
+    });
+
+    expect(screen.getByTestId('skill-card-jira-workflow')).toBeInTheDocument();
+    expect(screen.queryByTestId('skill-card-deck-gl')).toBeNull();
+    expect(screen.getByText('1 of 3')).toBeInTheDocument();
+  });
+
+  it('searches on the repo name too', async () => {
+    getMarketplace.mockResolvedValue(multiResponse);
+
+    await render();
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Search skills/), {
+      target: { value: 'team-skills' },
+    });
+
+    expect(screen.getByTestId('skill-card-release-notes')).toBeInTheDocument();
+    expect(screen.getByText('1 of 3')).toBeInTheDocument();
+  });
+
+  it('opens the drawer with the install command of the skill’s own repo', async () => {
+    getMarketplace.mockResolvedValue(multiResponse);
+
+    await render();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('skill-card-release-notes'),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('skill-card-release-notes'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Install in Claude Code')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        '/plugin marketplace add git@gitlab.com:my-group/team-skills.git',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('/plugin install release-notes@team-marketplace'),
+    ).toBeInTheDocument();
+    expect(getSkillDoc).toHaveBeenCalledWith(
+      './skills/release-notes',
+      'team-skills',
+    );
+  });
+
+  it('warns about marketplaces that failed to load', async () => {
+    getMarketplace.mockResolvedValue({
+      ...response,
+      errors: [
+        {
+          repo: 'broken-repo',
+          url: 'https://github.com/my-org/broken-repo/tree/main',
+          message: 'No .claude-plugin/marketplace.json found.',
+        },
+      ],
+    });
+
+    await render();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/1 marketplace could not be loaded/),
+      ).toBeInTheDocument();
+    });
+    // The marketplaces that did load are still shown.
+    expect(screen.getByTestId('skill-card-deck-gl')).toBeInTheDocument();
   });
 });

--- a/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
+++ b/plugins/skills-marketplace/src/SkillsMarketplacePage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import Box from '@material-ui/core/Box';
 import Chip from '@material-ui/core/Chip';
 import Grid from '@material-ui/core/Grid';
+import MenuItem from '@material-ui/core/MenuItem';
 import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Typography from '@material-ui/core/Typography';
@@ -12,20 +13,23 @@ import {
   Content,
   Progress,
   ResponseErrorPanel,
+  WarningPanel,
 } from '@backstage/core-components';
-import { Skill, skillsMarketplaceApiRef } from './api';
+import { SkillListing, flattenSkills, skillsMarketplaceApiRef } from './api';
 import { SkillCard } from './SkillCard';
 import { SkillDetailDrawer } from './SkillDetailDrawer';
 import { useSkillsStyles } from './styles';
 
 const ALL = '__all__';
 
-const matches = (skill: Skill, query: string): boolean => {
+const matches = (listing: SkillListing, query: string): boolean => {
   if (!query) return true;
+  const { skill } = listing;
   const haystack = [
     skill.name,
     skill.description,
     skill.category ?? '',
+    listing.repo,
     ...(skill.keywords ?? []),
   ]
     .join(' ')
@@ -43,30 +47,46 @@ export const SkillsMarketplacePage = () => {
 
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<string>(ALL);
-  const [selected, setSelected] = useState<Skill | null>(null);
+  const [repo, setRepo] = useState<string>(ALL);
+  const [selected, setSelected] = useState<SkillListing | null>(null);
 
   const { value, loading, error } = useAsync(
     () => skillsMarketplaceApi.getMarketplace(),
     [skillsMarketplaceApi],
   );
 
-  const marketplace = value?.marketplace;
+  const marketplaces = value?.marketplaces;
+  const failures = value?.errors ?? [];
+
+  const listings = useMemo(
+    () => flattenSkills(marketplaces ?? []),
+    [marketplaces],
+  );
 
   const categories = useMemo(() => {
     const set = new Set<string>();
-    marketplace?.plugins.forEach(p => p.category && set.add(p.category));
+    listings.forEach(l => l.skill.category && set.add(l.skill.category));
     return Array.from(set).sort();
-  }, [marketplace]);
+  }, [listings]);
 
-  const visible = useMemo(() => {
-    const plugins = marketplace?.plugins ?? [];
-    return plugins
-      .filter(p => category === ALL || p.category === category)
-      .filter(p => matches(p, query))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [marketplace, category, query]);
+  const repos = useMemo(
+    () => (marketplaces ?? []).map(entry => entry.repo).sort(),
+    [marketplaces],
+  );
 
-  const total = marketplace?.plugins.length ?? 0;
+  const visible = useMemo(
+    () =>
+      listings
+        .filter(l => repo === ALL || l.repo === repo)
+        .filter(l => category === ALL || l.skill.category === category)
+        .filter(l => matches(l, query))
+        .sort(
+          (a, b) =>
+            a.skill.name.localeCompare(b.skill.name) ||
+            a.repo.localeCompare(b.repo),
+        ),
+    [listings, repo, category, query],
+  );
 
   return (
     /* No <Page>/<Header>: the app shell renders the PageBlueprint title. */
@@ -74,7 +94,26 @@ export const SkillsMarketplacePage = () => {
       {loading && <Progress />}
       {error && <ResponseErrorPanel error={error} />}
 
-      {marketplace && (
+      {failures.length > 0 && (
+        <Box mb={2}>
+          <WarningPanel
+            severity="warning"
+            title={`${failures.length} marketplace${
+              failures.length === 1 ? '' : 's'
+            } could not be loaded`}
+          >
+            <ul className={classes.failureList}>
+              {failures.map(failure => (
+                <li key={failure.url}>
+                  <strong>{failure.repo}</strong> — {failure.message}
+                </li>
+              ))}
+            </ul>
+          </WarningPanel>
+        </Box>
+      )}
+
+      {marketplaces && (
         <>
           <Box className={classes.filters}>
             <TextField
@@ -92,6 +131,26 @@ export const SkillsMarketplacePage = () => {
                 ),
               }}
             />
+            {/* Repo filtering only earns its space with more than one repo. */}
+            {repos.length > 1 && (
+              <TextField
+                className={classes.repoFilter}
+                select
+                variant="outlined"
+                size="small"
+                label="Repo"
+                value={repo}
+                onChange={e => setRepo(e.target.value)}
+                inputProps={{ 'aria-label': 'Filter by repo' }}
+              >
+                <MenuItem value={ALL}>All repos</MenuItem>
+                {repos.map(name => (
+                  <MenuItem key={name} value={name}>
+                    {name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
             {categories.length > 0 && (
               <div className={classes.categories}>
                 <Chip
@@ -118,7 +177,7 @@ export const SkillsMarketplacePage = () => {
               variant="body2"
               className={classes.resultCount}
             >
-              {visible.length} of {total}
+              {visible.length} of {listings.length}
             </Typography>
           </Box>
 
@@ -128,9 +187,20 @@ export const SkillsMarketplacePage = () => {
             </Typography>
           ) : (
             <Grid container spacing={2}>
-              {visible.map(skill => (
-                <Grid item key={skill.name} xs={12} sm={6} md={4} lg={3}>
-                  <SkillCard skill={skill} onSelect={setSelected} />
+              {visible.map(listing => (
+                <Grid
+                  item
+                  key={`${listing.repo}/${listing.skill.name}`}
+                  xs={12}
+                  sm={6}
+                  md={4}
+                  lg={3}
+                >
+                  <SkillCard
+                    listing={listing}
+                    showRepo={repos.length > 1}
+                    onSelect={setSelected}
+                  />
                 </Grid>
               ))}
             </Grid>
@@ -138,14 +208,11 @@ export const SkillsMarketplacePage = () => {
         </>
       )}
 
-      {value && (
-        <SkillDetailDrawer
-          skill={selected}
-          marketplaceName={value.marketplace.name}
-          installUrl={value.installUrl}
-          onClose={() => setSelected(null)}
-        />
-      )}
+      <SkillDetailDrawer
+        listing={selected}
+        showRepo={repos.length > 1}
+        onClose={() => setSelected(null)}
+      />
     </Content>
   );
 };

--- a/plugins/skills-marketplace/src/alpha.test.tsx
+++ b/plugins/skills-marketplace/src/alpha.test.tsx
@@ -19,17 +19,24 @@ describe('alpha plugin', () => {
   it('renders the skills marketplace page', async () => {
     const mockApi = {
       getMarketplace: jest.fn().mockResolvedValue({
-        marketplace: {
-          name: 'my-marketplace',
-          plugins: [
-            {
-              name: 'deck-gl',
-              source: './skills/deck-gl',
-              description: 'Build PowerPoint decks',
+        marketplaces: [
+          {
+            repo: 'my-repo',
+            url: 'https://github.com/my-org/my-repo/tree/main',
+            installUrl: 'git@github.com:my-org/my-repo.git',
+            marketplace: {
+              name: 'my-marketplace',
+              plugins: [
+                {
+                  name: 'deck-gl',
+                  source: './skills/deck-gl',
+                  description: 'Build PowerPoint decks',
+                },
+              ],
             },
-          ],
-        },
-        installUrl: 'git@github.com:my-org/my-repo.git',
+          },
+        ],
+        errors: [],
       }),
       getSkillDoc: jest.fn().mockResolvedValue(undefined),
     } as unknown as SkillsMarketplaceApi;

--- a/plugins/skills-marketplace/src/api.test.ts
+++ b/plugins/skills-marketplace/src/api.test.ts
@@ -1,4 +1,9 @@
-import { SkillsMarketplaceClient, parseFrontmatter } from './api';
+import {
+  MarketplaceEntry,
+  SkillsMarketplaceClient,
+  flattenSkills,
+  parseFrontmatter,
+} from './api';
 
 const mockClient = (response: Partial<Response>) => {
   const fetch = jest.fn().mockResolvedValue({
@@ -20,8 +25,15 @@ describe('SkillsMarketplaceClient', () => {
   describe('getMarketplace', () => {
     it('fetches the marketplace from the backend', async () => {
       const payload = {
-        marketplace: { name: 'my-marketplace', plugins: [] },
-        installUrl: 'git@github.com:my-org/my-repo.git',
+        marketplaces: [
+          {
+            repo: 'my-repo',
+            url: 'https://github.com/my-org/my-repo/tree/main',
+            installUrl: 'git@github.com:my-org/my-repo.git',
+            marketplace: { name: 'my-marketplace', plugins: [] },
+          },
+        ],
+        errors: [],
       };
       const { client, fetch } = mockClient({ json: async () => payload });
 
@@ -55,6 +67,17 @@ describe('SkillsMarketplaceClient', () => {
       });
       expect(fetch).toHaveBeenCalledWith(
         'http://backend/api/skills-marketplace/skill-doc?source=.%2Fskills%2Ffoo',
+        expect.anything(),
+      );
+    });
+
+    it('passes the repo through when given', async () => {
+      const { client, fetch } = mockClient({ text: async () => 'body' });
+
+      await client.getSkillDoc('./skills/foo', 'team-skills');
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://backend/api/skills-marketplace/skill-doc?source=.%2Fskills%2Ffoo&repo=team-skills',
         expect.anything(),
       );
     });
@@ -121,5 +144,59 @@ describe('parseFrontmatter', () => {
 
     expect(frontmatter).toEqual({ name: 'x' });
     expect(body).toBe('body line');
+  });
+});
+
+describe('flattenSkills', () => {
+  const entry = (
+    repo: string,
+    name: string,
+    skillNames: string[],
+  ): MarketplaceEntry => ({
+    repo,
+    url: `https://github.com/my-org/${repo}/tree/main`,
+    installUrl: `git@github.com:my-org/${repo}.git`,
+    marketplace: {
+      name,
+      plugins: skillNames.map(skill => ({
+        name: skill,
+        source: `./skills/${skill}`,
+        description: `${skill} skill`,
+      })),
+    },
+  });
+
+  it('tags every skill with the marketplace it came from', () => {
+    const listings = flattenSkills([
+      entry('repo-a', 'marketplace-a', ['foo', 'bar']),
+      entry('repo-b', 'marketplace-b', ['baz']),
+    ]);
+
+    expect(
+      listings.map(l => [
+        l.skill.name,
+        l.repo,
+        l.marketplaceName,
+        l.installUrl,
+      ]),
+    ).toEqual([
+      ['foo', 'repo-a', 'marketplace-a', 'git@github.com:my-org/repo-a.git'],
+      ['bar', 'repo-a', 'marketplace-a', 'git@github.com:my-org/repo-a.git'],
+      ['baz', 'repo-b', 'marketplace-b', 'git@github.com:my-org/repo-b.git'],
+    ]);
+  });
+
+  it('keeps same-named skills from different repos apart', () => {
+    const listings = flattenSkills([
+      entry('repo-a', 'marketplace-a', ['foo']),
+      entry('repo-b', 'marketplace-b', ['foo']),
+    ]);
+
+    expect(listings).toHaveLength(2);
+    expect(listings.map(l => l.repo)).toEqual(['repo-a', 'repo-b']);
+  });
+
+  it('returns nothing for no marketplaces', () => {
+    expect(flattenSkills([])).toEqual([]);
   });
 });

--- a/plugins/skills-marketplace/src/api.ts
+++ b/plugins/skills-marketplace/src/api.ts
@@ -22,14 +22,59 @@ export type Marketplace = {
   plugins: Skill[];
 };
 
-/** The marketplace manifest plus repo metadata derived by the backend. */
-export type MarketplaceResponse = {
-  marketplace: Marketplace;
+/** One marketplace repo: its manifest plus metadata derived by the backend. */
+export type MarketplaceEntry = {
+  /** Repo name, e.g. `skills-marketplace` — the id used to filter skills. */
+  repo: string;
+  /** Web URL of the repo tree the manifest was read from. */
+  url: string;
   /** Git URL of the marketplace repo shown in the install command. */
+  installUrl: string;
+  marketplace: Marketplace;
+};
+
+/** A configured marketplace the backend could not load. */
+export type MarketplaceError = {
+  repo: string;
+  url: string;
+  message: string;
+};
+
+/** Every configured marketplace, plus any that failed to load. */
+export type MarketplaceResponse = {
+  marketplaces: MarketplaceEntry[];
+  errors?: MarketplaceError[];
+};
+
+/** A skill paired with the marketplace it was declared in. */
+export type SkillListing = {
+  skill: Skill;
+  /** Repo name of the marketplace this skill came from. */
+  repo: string;
+  /** Manifest `name` of that marketplace, used in the install command. */
+  marketplaceName: string;
+  /** Git URL of that marketplace repo, used in the install command. */
   installUrl: string;
 };
 
-/** A skill's `SKILL.md` split into frontmatter fields and the markdown body. */
+/** Flatten every marketplace's plugins into one list tagged by source repo. */
+export function flattenSkills(
+  marketplaces: MarketplaceEntry[],
+): SkillListing[] {
+  return marketplaces.flatMap(entry =>
+    entry.marketplace.plugins.map(skill => ({
+      skill,
+      repo: entry.repo,
+      marketplaceName: entry.marketplace.name,
+      installUrl: entry.installUrl,
+    })),
+  );
+}
+
+/**
+ * A skill's docs — its `SKILL.md`, or its `README.md` where it has no
+ * `SKILL.md` — split into frontmatter fields and the markdown body.
+ */
 export type SkillDoc = {
   /** Raw key/value pairs from the YAML frontmatter block (values kept as strings). */
   frontmatter: Record<string, string>;
@@ -39,8 +84,12 @@ export type SkillDoc = {
 
 export interface SkillsMarketplaceApi {
   getMarketplace(): Promise<MarketplaceResponse>;
-  /** Fetch a skill's SKILL.md; undefined when the skill has none. */
-  getSkillDoc(source: string): Promise<SkillDoc | undefined>;
+  /**
+   * Fetch a skill's docs (`SKILL.md`, else `README.md`) from the given repo;
+   * undefined when it has neither. Without a repo the first configured
+   * marketplace is used.
+   */
+  getSkillDoc(source: string, repo?: string): Promise<SkillDoc | undefined>;
 }
 
 export const skillsMarketplaceApiRef = createApiRef<SkillsMarketplaceApi>({
@@ -67,10 +116,17 @@ export class SkillsMarketplaceClient implements SkillsMarketplaceApi {
     return (await response.json()) as MarketplaceResponse;
   }
 
-  async getSkillDoc(source: string): Promise<SkillDoc | undefined> {
+  async getSkillDoc(
+    source: string,
+    repo?: string,
+  ): Promise<SkillDoc | undefined> {
     const baseUrl = await this.discoveryApi.getBaseUrl('skills-marketplace');
+    const query = new URLSearchParams({ source });
+    if (repo) {
+      query.set('repo', repo);
+    }
     const response = await this.fetchApi.fetch(
-      `${baseUrl}/skill-doc?source=${encodeURIComponent(source)}`,
+      `${baseUrl}/skill-doc?${query}`,
       { credentials: 'include' },
     );
     if (response.status === 404) {
@@ -96,7 +152,8 @@ export class SkillsMarketplaceClient implements SkillsMarketplaceApi {
 }
 
 /**
- * Split a SKILL.md into flat `key: value` frontmatter and markdown body.
+ * Split a doc into flat `key: value` frontmatter and markdown body. A README
+ * with no frontmatter block comes back as body only.
  * Not a general YAML parser — nested structures are kept as raw strings.
  */
 export function parseFrontmatter(raw: string): SkillDoc {

--- a/plugins/skills-marketplace/src/index.ts
+++ b/plugins/skills-marketplace/src/index.ts
@@ -3,11 +3,15 @@ export { rootRouteRef } from './routes';
 export {
   skillsMarketplaceApiRef,
   SkillsMarketplaceClient,
+  flattenSkills,
   parseFrontmatter,
 } from './api';
 export type {
   Skill,
+  SkillListing,
   Marketplace,
+  MarketplaceEntry,
+  MarketplaceError,
   MarketplaceResponse,
   SkillDoc,
   SkillsMarketplaceApi,

--- a/plugins/skills-marketplace/src/styles.ts
+++ b/plugins/skills-marketplace/src/styles.ts
@@ -14,6 +14,9 @@ export const useSkillsStyles = makeStyles(theme => ({
     flex: '1 1 260px',
     maxWidth: 480,
   },
+  repoFilter: {
+    minWidth: 180,
+  },
   categories: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -60,10 +63,18 @@ export const useSkillsStyles = makeStyles(theme => ({
   cardDescription: {
     flex: 1,
   },
+  cardRepo: {
+    marginTop: 'auto',
+  },
   chips: {
     display: 'flex',
     flexWrap: 'wrap',
     gap: theme.spacing(0.5),
+  },
+
+  failureList: {
+    margin: 0,
+    paddingLeft: theme.spacing(2.5),
   },
 
   /* Detail drawer */


### PR DESCRIPTION
Accept an optional `skillsMarketplace.marketplaces` list alongside (or instead of) the single `url`, so skills can be pulled in from several repos at once. Each entry takes a repo tree `url` and may override `installUrlFormat`; repo names must be unique, since the repo name identifies a marketplace in both the API and the UI.

Skills from every configured repo are listed together and tagged with their source repo, with a new Repo filter (shown only when more than one marketplace is configured) that composes with the existing search and category filters. The repo name is searchable too, and each skill's install commands use its own repo's git URL and marketplace name. A marketplace that fails to load no longer breaks the page: the rest still render and the failure is surfaced as a warning.

Skill docs now fall back to README.md when a plugin has no SKILL.md, so plugins documented with only a README render docs instead of an empty state.

GET /marketplace now returns `{ marketplaces: [...], errors }` rather than `{ marketplace, installUrl }`, and GET /skill-doc accepts an optional `repo` query parameter, so the frontend and backend must be upgraded together.