### PR TITLE
feat(tech-insights-overview): grade category colours by pass rate

### DIFF
--- a/.changeset/tech-insights-graded-meters.md
+++ b/.changeset/tech-insights-graded-meters.md
@@ -1,0 +1,11 @@
+---
+'@globallogicuki/backstage-plugin-tech-insights-overview': minor
+---
+
+Colour the catalog-wide overview on a sliding scale rather than pass/fail:
+
+- **Check and category tiles** now fill their meter to the pass rate and hue it on a continuous red-to-green ramp, replacing the previous three-step neutral/warning/critical buckets that put anything from 25% to 100% failing into the same red. A standard almost everyone meets no longer looks like one nobody meets. The meter fill also switches from the failing share to the passing share, so bar length and hue tell the same story.
+- **Category cells in the scorecard matrix** take the same ramp, graded by how many of that category's checks the component passes. Previously one missing check out of six and six out of six were both a flat red dot. Cells covering a single check stay flat pass/fail, since there is nothing between passed and failed to grade.
+- Matrix cells now name their count — "Docs: failed (5 of 6 checks passed)" — in the tooltip and accessible name, so the gradient is never colour alone.
+
+`FailingEntity` gains `categoryTallies`, the per-category passed/total counts behind a cell's colour. `FailuresTable` gains an optional `cellRatio` prop; without it, cells keep the flat colouring. `checkSeverity` and the `Severity` type are replaced by `meterColor`.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -207,6 +207,37 @@ techInsights:
               - fact: hasTags
                 operator: equal
                 value: true
+      # Two checks per category, deliberately: with one check apiece every
+      # category could only ever be 0% or 100%, which is exactly the all-or-
+      # nothing colouring the graded meter exists to replace.
+      hasGroupOwner:
+        type: json-rules-engine
+        name: Has group owner
+        description: spec.owner refers to a group rather than a single user
+        metadata:
+          category: Ownership
+        factIds:
+          - entityOwnershipFactRetriever
+        rule:
+          conditions:
+            all:
+              - fact: hasGroupOwner
+                operator: equal
+                value: true
+      hasTitle:
+        type: json-rules-engine
+        name: Has title
+        description: The entity has a human-readable metadata.title
+        metadata:
+          category: Documentation
+        factIds:
+          - entityMetadataFactRetriever
+        rule:
+          conditions:
+            all:
+              - fact: hasTitle
+                operator: equal
+                value: true
 
 proxy:
   {}

--- a/examples/entities.yaml
+++ b/examples/entities.yaml
@@ -12,6 +12,11 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: example-website
+  title: Example Website
+  description: The example website, fully documented and tagged.
+  tags:
+    - website
+    - example
   annotations:
     terraform/organization: GLUK
     terraform/workspaces: compliace-as-code-workshop-example-workspace
@@ -28,6 +33,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: example-service
+  description: The example service, described but neither titled nor tagged.
   annotations:
     terraform/organization: orgName
     terraform/workspaces: workspaceName1,workspaceName2,workspaceName3
@@ -43,6 +49,9 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: example-grpc-api
+  title: Example gRPC API
+  tags:
+    - api
 spec:
   type: grpc
   lifecycle: experimental
@@ -58,3 +67,16 @@ spec:
     message ExampleMessage {
       string example = 1;
     };
+---
+# Deliberately thin: owned by a user rather than a group, and carrying no
+# title, description, or tags. Without an entity like this every check passes
+# for every component and the overview page has no gradient to show.
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: example-orphan
+spec:
+  type: service
+  lifecycle: experimental
+  owner: user:guest
+  system: examples

--- a/plugins/tech-insights-overview/src/TechInsightsOverviewPage.test.tsx
+++ b/plugins/tech-insights-overview/src/TechInsightsOverviewPage.test.tsx
@@ -221,15 +221,17 @@ describe('TechInsightsOverviewPage', () => {
         'Documentation',
       ]);
 
-      // Both fail Security; api meets Documentation and web does not.
+      // Both fail Security; api meets Documentation and web does not. The
+      // name also carries the check count behind the cell's colour, so these
+      // match on the verdict rather than the whole string.
       expect(
-        screen.getAllByRole('img', { name: 'Security: failed' }),
+        screen.getAllByRole('img', { name: /^Security: failed/ }),
       ).toHaveLength(2);
       expect(
-        screen.getAllByRole('img', { name: 'Documentation: passed' }),
+        screen.getAllByRole('img', { name: /^Documentation: passed/ }),
       ).toHaveLength(1);
       expect(
-        screen.getAllByRole('img', { name: 'Documentation: failed' }),
+        screen.getAllByRole('img', { name: /^Documentation: failed/ }),
       ).toHaveLength(1);
 
       // The tile row is the only category control.

--- a/plugins/tech-insights-overview/src/TechInsightsOverviewPage.tsx
+++ b/plugins/tech-insights-overview/src/TechInsightsOverviewPage.tsx
@@ -36,6 +36,10 @@ const categoryCellState = (entity: FailingEntity, key: string): CellState => {
   return 'unscored';
 };
 
+/** How many of a category's checks this component passes, for the cell's hue. */
+const categoryCellRatio = (entity: FailingEntity, key: string) =>
+  entity.categoryTallies[key] ?? null;
+
 /** The same, for a check column. */
 const checkCellState = (entity: FailingEntity, key: string): CellState => {
   if (entity.failedCheckIds.includes(key)) return 'failed';
@@ -329,6 +333,9 @@ export const TechInsightsOverviewPage = () => {
                 cellState={
                   showCategoryColumns ? categoryCellState : checkCellState
                 }
+                /* Only category cells stand for more than one check; a check
+                   column's dot has nothing to grade. */
+                cellRatio={showCategoryColumns ? categoryCellRatio : undefined}
                 highlightedColumn={showCategoryColumns ? null : selectedCheck}
               />
             </Box>

--- a/plugins/tech-insights-overview/src/components/CheckTiles.tsx
+++ b/plugins/tech-insights-overview/src/components/CheckTiles.tsx
@@ -6,14 +6,15 @@ import Typography from '@material-ui/core/Typography';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import type { CheckSummary } from '../useTechInsightsOverview';
-import { checkSeverity, useOverviewStyles } from '../styles';
+import { meterColor, useOverviewStyles } from '../styles';
 
 /**
  * One tile per check (or per category) in a single scrollable row, doubling as
  * the page's primary filter. The arrows in the header page the row; trackpads
- * and touch scroll it directly, so the scrollbar itself is hidden. A tile is
- * neutral unless the check is actually being missed, so a healthy catalog is a
- * page with no color.
+ * and touch scroll it directly, so the scrollbar itself is hidden. Each tile's
+ * meter is filled to its pass rate and coloured on a red-to-green ramp, so a
+ * row of tiles can be read at a glance and near-misses are told apart from
+ * standards nobody is meeting.
  *
  * `parent` turns the heading into a breadcrumb, for when this row is one level
  * of a drill-down rather than the whole story.
@@ -107,17 +108,12 @@ export const CheckTiles = ({
         aria-label={title}
       >
         {checks.map(check => {
-          const severity = checkSeverity(check.failing, check.total);
           const passing = check.total - check.failing;
           const pct = check.total
             ? Math.round((passing / check.total) * 100)
             : 100;
           const selected = selectedId === check.id;
-          const fillClass = {
-            critical: classes.meterCritical,
-            warning: classes.meterWarning,
-            none: '',
-          }[severity];
+          const fill = meterColor(check.failing, check.total);
 
           return (
             <ButtonBase
@@ -149,14 +145,13 @@ export const CheckTiles = ({
               <Box
                 className={classes.meter}
                 role="img"
-                aria-label={`${check.failing} of ${check.total} components failing`}
+                aria-label={`${passing} of ${check.total} components passing`}
               >
                 <Box
-                  className={`${classes.meterFill} ${fillClass}`}
+                  className={classes.meterFill}
                   style={{
-                    width: check.total
-                      ? `${(check.failing / check.total) * 100}%`
-                      : 0,
+                    width: `${pct}%`,
+                    ...(fill ? { backgroundColor: fill } : {}),
                   }}
                 />
               </Box>

--- a/plugins/tech-insights-overview/src/components/FailuresTable.test.tsx
+++ b/plugins/tech-insights-overview/src/components/FailuresTable.test.tsx
@@ -1,0 +1,68 @@
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import { FailuresTable } from './FailuresTable';
+import type { FailingEntity } from '../useTechInsightsOverview';
+
+const entity = (
+  name: string,
+  tallies: Record<string, { passed: number; total: number }>,
+  failedCategories: string[],
+): FailingEntity => ({
+  ref: `component:default/${name}`,
+  name,
+  ownerRef: 'group:default/team',
+  owner: 'team',
+  ownerKind: 'group',
+  failing: 1,
+  total: 4,
+  checkIds: [],
+  failedCheckIds: [],
+  failedCheckNames: [],
+  failedCategories,
+  scoredCategories: Object.keys(tallies),
+  categoryTallies: tallies,
+});
+
+const columns = [{ key: 'Docs', label: 'Docs' }];
+const cellState = (e: FailingEntity, key: string) => {
+  if (e.failedCategories.includes(key)) return 'failed' as const;
+  if (e.scoredCategories.includes(key)) return 'passed' as const;
+  return 'unscored' as const;
+};
+
+const dotColor = (label: string) =>
+  screen.getByLabelText(label, { exact: false }).style.backgroundColor;
+
+describe('FailuresTable category dots', () => {
+  it('grades a near-miss differently from a total miss', async () => {
+    await renderInTestApp(
+      <FailuresTable
+        entities={[
+          entity('nearly', { Docs: { passed: 5, total: 6 } }, ['Docs']),
+          entity('nowhere', { Docs: { passed: 0, total: 6 } }, ['Docs']),
+        ]}
+        columns={columns}
+        cellState={cellState}
+        cellRatio={(e, key) => e.categoryTallies[key] ?? null}
+      />,
+    );
+
+    const nearly = dotColor('Docs: failed (5 of 6 checks passed)');
+    const nowhere = dotColor('Docs: failed (0 of 6 checks passed)');
+    expect(nearly).not.toBe('');
+    expect(nearly).not.toBe(nowhere);
+  });
+
+  it('leaves a single-check cell on the flat pass/fail colour', async () => {
+    await renderInTestApp(
+      <FailuresTable
+        entities={[entity('solo', { Docs: { passed: 0, total: 1 } }, ['Docs'])]}
+        columns={columns}
+        cellState={cellState}
+        cellRatio={(e, key) => e.categoryTallies[key] ?? null}
+      />,
+    );
+
+    expect(dotColor('Docs: failed (0 of 1 checks passed)')).toBe('');
+  });
+});

--- a/plugins/tech-insights-overview/src/components/FailuresTable.tsx
+++ b/plugins/tech-insights-overview/src/components/FailuresTable.tsx
@@ -9,7 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import { Link } from '@backstage/core-components';
 import type { FailingEntity } from '../useTechInsightsOverview';
 import { entityHref } from '../links';
-import { useOverviewStyles } from '../styles';
+import { meterColor, useOverviewStyles } from '../styles';
 import { OwnerGlyph } from './OwnerGlyph';
 
 /** One column of the matrix — a category, or a check within one. */
@@ -42,16 +42,30 @@ const CELL_WORDS: Record<CellState, string> = {
  * Cells are never colour alone: each carries a tooltip and an accessible name
  * spelling out the standard and its state, and `unscored` renders as a dash
  * rather than a mark so "no facts yet" cannot read as a pass.
+ *
+ * A category cell also reports how many of its checks passed, and `cellRatio`
+ * hues the dot on the same red-to-green ramp the tiles use — one check missing
+ * out of six should not look identical to all six missing. Without a ratio the
+ * dot falls back to flat pass/fail, which is all a single check can say.
  */
 export const FailuresTable = ({
   entities,
   columns,
   cellState,
+  cellRatio,
   highlightedColumn = null,
 }: {
   entities: FailingEntity[];
   columns: MatrixColumn[];
   cellState: (entity: FailingEntity, key: string) => CellState;
+  /**
+   * How many of this cell's checks passed, when the cell stands for more than
+   * one. Returning null keeps the flat pass/fail colouring.
+   */
+  cellRatio?: (
+    entity: FailingEntity,
+    key: string,
+  ) => { passed: number; total: number } | null;
   /** Column to emphasise — the one the page is scoped to, if any. */
   highlightedColumn?: string | null;
 }) => {
@@ -107,7 +121,16 @@ export const FailuresTable = ({
               </TableCell>
               {columns.map(column => {
                 const state = cellState(entity, column.key);
-                const label = `${column.label}: ${CELL_WORDS[state]}`;
+                const ratio = cellRatio?.(entity, column.key) ?? null;
+                /* Only worth grading when the cell covers several checks —
+                   a lone check has nothing between passed and failed. */
+                const graded =
+                  state !== 'unscored' && ratio && ratio.total > 1
+                    ? meterColor(ratio.total - ratio.passed, ratio.total)
+                    : null;
+                const label = ratio
+                  ? `${column.label}: ${CELL_WORDS[state]} (${ratio.passed} of ${ratio.total} checks passed)`
+                  : `${column.label}: ${CELL_WORDS[state]}`;
                 return (
                   <TableCell key={column.key} align="center">
                     <Tooltip title={label}>
@@ -126,6 +149,9 @@ export const FailuresTable = ({
                               ? classes.markFailed
                               : classes.markPassed
                           }`}
+                          style={
+                            graded ? { backgroundColor: graded } : undefined
+                          }
                           role="img"
                           aria-label={label}
                         />

--- a/plugins/tech-insights-overview/src/styles.test.ts
+++ b/plugins/tech-insights-overview/src/styles.test.ts
@@ -1,0 +1,17 @@
+import { meterColor } from './styles';
+
+describe('meterColor', () => {
+  it('ramps from red at none passing to green at all passing', () => {
+    expect(meterColor(10, 10)).toBe('hsl(0, 62%, 45%)');
+    expect(meterColor(5, 10)).toBe('hsl(60, 62%, 45%)');
+    expect(meterColor(0, 10)).toBe('hsl(120, 62%, 45%)');
+  });
+
+  it('grades between the extremes rather than bucketing', () => {
+    expect(meterColor(1, 10)).not.toBe(meterColor(9, 10));
+  });
+
+  it('leaves an unscored meter to the theme', () => {
+    expect(meterColor(0, 0)).toBeNull();
+  });
+});

--- a/plugins/tech-insights-overview/src/styles.ts
+++ b/plugins/tech-insights-overview/src/styles.ts
@@ -1,17 +1,21 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 /**
- * How red a check tile is allowed to look. A quarter of the catalog failing a
- * check is a standard nobody is meeting; anything else failing is a warning;
- * zero stays neutral.
+ * Meter colour as a continuous ramp from red at 0% passing to green at 100%,
+ * through amber in the middle — so a category at 90% reads visibly healthier
+ * than one at 30%, rather than both landing in the same "critical" bucket.
+ *
+ * ponytail: hand-rolled hsl interpolation rather than a colour library. Hue
+ * 0→120 with fixed saturation/lightness is close enough at meter size; reach
+ * for a perceptual space (oklch) only if the mid-range reads muddy.
+ *
+ * Nothing scored is not a pass: that stays neutral, and the tile's own "n of m
+ * failing" line is what carries the state to anyone who cannot read the hue.
  */
-const CRITICAL_FAILURE_RATE = 0.25;
-
-export type Severity = 'none' | 'warning' | 'critical';
-
-export const checkSeverity = (failing: number, total: number): Severity => {
-  if (failing === 0 || total === 0) return 'none';
-  return failing / total >= CRITICAL_FAILURE_RATE ? 'critical' : 'warning';
+export const meterColor = (failing: number, total: number): string | null => {
+  if (total === 0) return null;
+  const passRate = (total - failing) / total;
+  return `hsl(${Math.round(passRate * 120)}, 62%, 45%)`;
 };
 
 /** Layout-only styles — colors, fonts, and radii come from the host theme. */
@@ -149,7 +153,7 @@ export const useOverviewStyles = makeStyles(theme => {
       fontVariantNumeric: 'tabular-nums',
     },
 
-    /* Meter: neutral track, colored only when it matters */
+    /* Meter: neutral track; the fill is the pass rate, hued by meterColor. */
     meter: {
       height: 6,
       position: 'relative',
@@ -167,8 +171,6 @@ export const useOverviewStyles = makeStyles(theme => {
           ? theme.palette.grey[400]
           : theme.palette.grey[700],
     },
-    meterWarning: { backgroundColor: theme.palette.warning.main },
-    meterCritical: { backgroundColor: theme.palette.error.main },
 
     /* Filters */
     filters: {

--- a/plugins/tech-insights-overview/src/useTechInsightsOverview.ts
+++ b/plugins/tech-insights-overview/src/useTechInsightsOverview.ts
@@ -43,6 +43,15 @@ export type FailingEntity = {
    * as meeting it.
    */
   scoredCategories: string[];
+  /**
+   * How many of each category's checks this component passes.
+   *
+   * `failedCategories` is the verdict; this is the margin behind it. A
+   * component missing one check of six and one missing all six both "fail" the
+   * category, and a matrix of identical red dots cannot tell them apart — so
+   * the dot takes its colour from this instead.
+   */
+  categoryTallies: Record<string, { passed: number; total: number }>;
 };
 
 export type CheckSummary = {
@@ -266,6 +275,12 @@ export const aggregateInsights = (
       failedCheckNames,
       failedCategories,
       scoredCategories: [...componentCategories.keys()],
+      categoryTallies: Object.fromEntries(
+        [...componentCategories].map(([name, t]) => [
+          name,
+          { passed: t.total - t.failed, total: t.total },
+        ]),
+      ),
     });
 
     const tally = ownerTotals.get(ownerRef) ?? {


### PR DESCRIPTION
## What

The tech-insights overview page coloured everything pass/fail. This puts both the tiles and the matrix dots on a continuous red-to-green ramp keyed to the pass rate.

Two places were flattening real differences:

- **Check/category tiles** fell into three buckets — neutral, warning, or critical at 25% failing. A standard 26% of the catalog missed looked identical to one nobody met.
- **Category dots in the matrix** were a single boolean per component per category, so missing one check out of six rendered the same red as missing all six.

## How

- `checkSeverity` and the `Severity` type give way to `meterColor`, an hsl hue interpolation from 0 (red) to 120 (green). Tile meters now fill to the *passing* share rather than the failing one, so bar length and hue tell the same story.
- Matrix category cells take the same ramp via a new optional `cellRatio` prop on `FailuresTable`, backed by `categoryTallies` on `FailingEntity` — the per-category passed/total counts the aggregation already computed and then discarded.
- Cells covering a single check stay flat pass/fail; there is nothing between passed and failed to grade.

Colour is still never the only signal — cells now name their count in the tooltip and accessible name (`"Docs: failed (5 of 6 checks passed)"`). That is what moved one existing assertion to a prefix match.

## Demo app

`app-config.yaml` gains two checks (`hasGroupOwner`, `hasTitle`) built on facts the stock retrievers already emit but nothing consumed, and `examples/entities.yaml` gets varied metadata. With one check per category and no entity metadata every category sat at 0% or 100%, so the ramp had nothing to show. The example data now lands at Ownership 80% / Discoverability 40% / Documentation 20%.

## Testing

- `yarn tsc` — clean
- `yarn lint` — clean
- `yarn test` — 592 passing, 64 suites
- New: `styles.test.ts` (the ramp endpoints and the unscored case) and `FailuresTable.test.tsx` (a near-miss dot differs from a total miss; a single-check cell stays flat)

Not yet verified in a running app — the dev server needs `PATH` pointed at Node 22, since `node_modules` (`better-sqlite3`) is built for ABI 127 and Homebrew's Node 26 on `PATH` fails every backend plugin. Worth a look in the browser before merging.

## Notes for review

`minor` rather than patch: `FailingEntity` gains `categoryTallies`, `FailuresTable` gains `cellRatio`, and `checkSeverity`/`Severity` are removed from an exported module.

The ramp is hand-rolled hsl rather than a colour library — marked with a `ponytail:` comment naming oklch as the upgrade path if the mid-range reads muddy in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)